### PR TITLE
Add new DataContext constructor without tablename prefix

### DIFF
--- a/Sources/Linq2DynamoDb.DataContext.Tests/App.config
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/App.config
@@ -5,6 +5,7 @@
     <sectionGroup name="enyim.com">
       <section name="memcached" type="Enyim.Caching.Configuration.MemcachedClientSection, Enyim.Caching" />
     </sectionGroup>
+    <section name="aws" type="Amazon.AWSSection, AWSSDK.Core"/>
   </configSections>
   <appSettings>
     <add key="AwsCredentialsFilePath" value="C:\aws_credentials.xml" />
@@ -18,6 +19,11 @@ It is also possible to registered an accounts using the <solution-dir>/packages/
 that is bundled with the nuget package under the tools folder.-->
     <add key="AWSProfileName" value="" />
   </appSettings>
+  <aws region="eu-west-1" profileName="">
+    <dynamoDB>
+        <dynamoDBContext tableNamePrefix="VolatileTest-"/>
+      </dynamoDB>
+  </aws>
   <system.net>
     <defaultProxy useDefaultCredentials="true" />
   </system.net>

--- a/Sources/Linq2DynamoDb.DataContext.Tests/DataContextTests.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/DataContextTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Linq2DynamoDb.DataContext.Tests.Entities;
+
+using NUnit.Framework;
+
+namespace Linq2DynamoDb.DataContext.Tests
+{
+    [TestFixture]
+    public class DataContextTests
+    {
+        [Test]
+        public void DataContext()
+        {
+            var client = TestConfiguration.GetDynamoDbClient();
+            var ctx = new DataContext(client);
+            ctx.CreateTableIfNotExists(
+                new CreateTableArgs<Book>(
+                    1,
+                    1,
+                    r => r.Name,
+                    r => r.PublishYear,
+                    null,
+                    null,
+                    () =>
+                        new[]
+                        {
+                            new Book
+                            {
+                                Name = "TestBook" + Guid.NewGuid(),
+                                PublishYear = 2016,
+                                Author = "foo",
+                                NumPages = 25,
+                                PopularityRating = default(Book.Popularity),
+                                UserFeedbackRating = default(Book.Stars),
+                                RentingHistory = default(List<string>),
+                                FilmsBasedOnBook = default(IDictionary<string, TimeSpan>),
+                                LastRentTime = default(DateTime),
+                                Publisher = default(Book.PublisherDto),
+                                ReviewsList = default(List<Book.ReviewDto>)
+                            }
+                        }));
+
+            var table = ctx.GetTable<Book>();
+
+            //TODO: figure out a way to directly prove that the tablename prefix is getting applied, rather than this indirect approach
+            var result = table.FirstOrDefault();
+            Assert.IsNotNull(result);
+        }
+    }
+}

--- a/Sources/Linq2DynamoDb.DataContext.Tests/Linq2DynamoDb.DataContext.Tests.csproj
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/Linq2DynamoDb.DataContext.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="CachingTests\PredefinedHashKeyCachingTests2.cs" />
     <Compile Include="CachingTests\PredefinedHashKeyCachingTests.cs" />
     <Compile Include="CachingTests\StringFieldComparisonTests.cs" />
+    <Compile Include="DataContextTests.cs" />
     <Compile Include="Entities\BooksComparer.cs" />
     <Compile Include="EntityManagementTests\EntityCreationTests.cs" />
     <Compile Include="EntityManagementTests\EntityModificationTests.cs" />

--- a/Sources/Linq2DynamoDb.DataContext.Tests/TestConfiguration.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/TestConfiguration.cs
@@ -25,7 +25,10 @@ namespace Linq2DynamoDb.DataContext.Tests
 
 		public static AWSCredentials GetAwsCredentials()
 		{
-			var file = new FileInfo(AwsCredentialsFilePath);
+			// returning null means we're providing credentials in some other way than a credentials file
+		    if (string.IsNullOrEmpty(AwsCredentialsFilePath)) return null;
+
+		    var file = new FileInfo(AwsCredentialsFilePath);
 			if (!file.Exists)
 			{
 				// Create subdirectories
@@ -60,8 +63,10 @@ namespace Linq2DynamoDb.DataContext.Tests
 
 		public static IAmazonDynamoDB GetDynamoDbClient()
 		{
-		    return new AmazonDynamoDBClient(GetAwsCredentials(), DynamoDbRegion);
-		}
+            // uncomment this line to get tests working without credentials file
+            //return new AmazonDynamoDBClient();
+            return new AmazonDynamoDBClient(GetAwsCredentials(), DynamoDbRegion);
+        }
 
         public static DynamoDBContext GetDynamoDbContext()
         {

--- a/Sources/Linq2DynamoDb.DataContext/DataContext.cs
+++ b/Sources/Linq2DynamoDb.DataContext/DataContext.cs
@@ -2,6 +2,8 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
+
+using Amazon;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
 using Linq2DynamoDb.DataContext.Caching;
@@ -36,6 +38,18 @@ namespace Linq2DynamoDb.DataContext
         public DataContext(string tableNamePrefix)
         {
             this._tableNamePrefix = tableNamePrefix;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Linq2DynamoDb.DataContext.DataContext class. If a table
+        /// prefix is specified in config, it will be picked up automatically, rather than explicitly
+        /// defining it in the constructor.
+        /// </summary>
+        /// <param name="client">   Returns an AmazonDynamoDb instance passed via ctor. </param>
+        public DataContext(IAmazonDynamoDB client)
+        {
+            this._client = client;
+            this._tableNamePrefix = AWSConfigsDynamoDB.Context.TableNamePrefix;
         }
 
         #endregion


### PR DESCRIPTION
Adds new DataContext constructor without tablename prefix. Instead, the prefix is picked up from the config automatically. This allows us to leverage the existing AWS config semantics instead of use custom config settings.

Example config block is:
```xml
<aws region="eu-west-1" profileName="">
    <dynamoDB>
        <dynamoDBContext tableNamePrefix="VolatileTest-"/>
    </dynamoDB>
</aws>
```

Added test to (indirectly) prove that the above change works

Also changed TestConfiguration.GetDynamoDbClient() to return null if no AWS credentials file is found to support using AWS profile