### PR TITLE
RedisTableCache

### DIFF
--- a/Sources/Linq2DynamoDb.DataContext/Caching/EnyimMemcachedClient.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/EnyimMemcachedClient.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Enyim.Caching;
+using Enyim.Caching.Memcached;
+
+namespace Linq2DynamoDb.DataContext.Caching
+{
+	public class EnyimMemcachedClient : ICacheClient
+	{
+		MemcachedClient _cacheClient;
+		public TimeSpan DefaultTimeToLive { get; set; }
+
+		public EnyimMemcachedClient(MemcachedClient client, TimeSpan? defaultTtl = null)
+		{
+			_cacheClient = client;
+			DefaultTimeToLive = defaultTtl ?? TimeSpan.FromMinutes(15);
+		}
+
+		//public string this[string key]
+		//{
+		//	get
+		//	{
+		//		throw new NotImplementedException();
+		//	}
+		//	set
+		//	{
+		//		throw new NotImplementedException();
+		//	}
+		//}
+
+		//public string this[string key, DateTime expiration]
+		//{
+		//	set { throw new NotImplementedException(); }
+		//}
+
+		//public string this[string key, TimeSpan? timeToLive]
+		//{
+		//	set { throw new NotImplementedException(); }
+		//}
+
+		public bool Remove(string key)
+		{
+			return _cacheClient.Remove(key);
+		}
+
+		public bool TryRemove(string key)
+		{
+			var removeResult = this._cacheClient.ExecuteRemove(key);
+			return (removeResult.InnerResult == null) ||
+				   (removeResult.InnerResult.Exception == null);
+		}
+
+		public bool TryGetValue<T>(string key, out T value)
+		{
+			value = default(T);
+			var result = _cacheClient.ExecuteGet<T>(key);
+			if (result.Success)
+				value = result.Value;
+			
+			return result.Success;
+		}
+
+		//public bool TryGetValue<T>(string key, out T value, out TimeSpan? timeToLive)
+		//{
+		//	throw new NotImplementedException();
+		//}
+
+		//public bool TryGetValue<T>(string key, out T value, out DateTime? expiration)
+		//{
+		//	throw new NotImplementedException();
+		//}
+
+		//public bool TryGetTimeToLive(string key, out TimeSpan? timetoLive)
+		//{
+		//	throw new NotImplementedException();
+		//}
+
+		public bool AddValue<T>(string key, T value)
+		{
+			return _cacheClient.Store(StoreMode.Add, key, value, DefaultTimeToLive);
+		}
+
+		public bool AddValue<T>(string key, T value, TimeSpan? timeToLive)
+		{
+			return _cacheClient.Store(StoreMode.Add, key, value, timeToLive ?? DefaultTimeToLive);
+		}
+
+		public bool AddValue<T>(string key, T value, DateTime? expiration)
+		{
+			return StoreWithExpiration(StoreMode.Add, key, value, expiration);
+		}
+
+		public bool SetValue<T>(string key, T value)
+		{
+			return _cacheClient.Store(StoreMode.Set, key, value, DefaultTimeToLive);
+		}
+
+		public bool SetValue<T>(string key, T value, TimeSpan? timeToLive)
+		{
+			return _cacheClient.Store(StoreMode.Set, key, value, timeToLive ?? DefaultTimeToLive);
+		}
+
+		public bool SetValue<T>(string key, T value, DateTime? expiration)
+		{
+			return StoreWithExpiration(StoreMode.Set, key, value, expiration);
+		}
+
+		public bool ReplaceValue<T>(string key, T value)
+		{
+			return _cacheClient.Store(StoreMode.Replace, key, value, DefaultTimeToLive);
+		}
+
+		public bool ReplaceValue<T>(string key, T value, TimeSpan? timeToLive)
+		{
+			return _cacheClient.Store(StoreMode.Replace, key, value, timeToLive ?? DefaultTimeToLive);
+		}
+
+		public bool ReplaceValue<T>(string key, T value, DateTime? expiration)
+		{
+			return StoreWithExpiration(StoreMode.Replace, key, value, expiration);
+		}
+
+		private bool StoreWithExpiration<T>(StoreMode mode, string key, T value, DateTime? expiration)
+		{
+			if (expiration.HasValue)
+			{
+				if (expiration.Value.Kind != DateTimeKind.Utc)
+					expiration = expiration.Value.ToUniversalTime();
+			}
+			else
+			{
+				expiration = DateTime.UtcNow + DefaultTimeToLive;
+			}
+			return _cacheClient.Store(mode, key, value, expiration.Value);
+		}
+
+		//public bool SetTimeToLive(string key, TimeSpan? timetoLive)
+		//{
+		//	object value;
+		//	if (!TryGetValue<object>(key, out value))
+		//		return false;
+
+		//	return ReplaceValue<object>(key, value, )
+		//}
+	}
+}

--- a/Sources/Linq2DynamoDb.DataContext/Caching/EnyimMemcachedClient.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/EnyimMemcachedClient.cs
@@ -19,28 +19,6 @@ namespace Linq2DynamoDb.DataContext.Caching
 			DefaultTimeToLive = defaultTtl ?? TimeSpan.FromMinutes(15);
 		}
 
-		//public string this[string key]
-		//{
-		//	get
-		//	{
-		//		throw new NotImplementedException();
-		//	}
-		//	set
-		//	{
-		//		throw new NotImplementedException();
-		//	}
-		//}
-
-		//public string this[string key, DateTime expiration]
-		//{
-		//	set { throw new NotImplementedException(); }
-		//}
-
-		//public string this[string key, TimeSpan? timeToLive]
-		//{
-		//	set { throw new NotImplementedException(); }
-		//}
-
 		public bool Remove(string key)
 		{
 			return _cacheClient.Remove(key);
@@ -62,21 +40,6 @@ namespace Linq2DynamoDb.DataContext.Caching
 			
 			return result.Success;
 		}
-
-		//public bool TryGetValue<T>(string key, out T value, out TimeSpan? timeToLive)
-		//{
-		//	throw new NotImplementedException();
-		//}
-
-		//public bool TryGetValue<T>(string key, out T value, out DateTime? expiration)
-		//{
-		//	throw new NotImplementedException();
-		//}
-
-		//public bool TryGetTimeToLive(string key, out TimeSpan? timetoLive)
-		//{
-		//	throw new NotImplementedException();
-		//}
 
 		public bool AddValue<T>(string key, T value)
 		{
@@ -136,14 +99,5 @@ namespace Linq2DynamoDb.DataContext.Caching
 			}
 			return _cacheClient.Store(mode, key, value, expiration.Value);
 		}
-
-		//public bool SetTimeToLive(string key, TimeSpan? timetoLive)
-		//{
-		//	object value;
-		//	if (!TryGetValue<object>(key, out value))
-		//		return false;
-
-		//	return ReplaceValue<object>(key, value, )
-		//}
 	}
 }

--- a/Sources/Linq2DynamoDb.DataContext/Caching/EnyimProjectionIndexCreator.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/EnyimProjectionIndexCreator.cs
@@ -9,44 +9,41 @@ namespace Linq2DynamoDb.DataContext.Caching
         /// <summary>
         /// Implements the process of creating and filling the projection (readonly) index
         /// </summary>
-        private class EnyimProjectionIndexCreator : IIndexCreator
+        private class EnyimProjectionIndexCreator : ProjectionIndexCreator
         {
-            private readonly EnyimTableCache _parent;
+            private EnyimTableCache _tableCache
+			{
+				get { return (EnyimTableCache) _parent; }
+			}
 
-            private readonly TableProjectionIndex _index;
-            private readonly string _indexKey;
-            private readonly string _indexKeyInCache;
             private ulong _indexVersionInCache;
 
             internal EnyimProjectionIndexCreator(EnyimTableCache parent, string indexKey, string indexKeyInCache, SearchConditions searchConditions)
+				: base(parent, indexKey, indexKeyInCache, searchConditions)
             {
-                this._parent = parent;
-                this._index = new TableProjectionIndex(searchConditions);
-                this._indexKey = indexKey;
-                this._indexKeyInCache = indexKeyInCache;
             }
 
-            public bool StartCreatingIndex()
+            public override bool StartCreatingIndex()
             {
                 // Marking the index as being rebuilt.
                 // Note: we're using Set mode. This means, that if an index exists in cache, it will be 
                 // overwritten. That's OK, because if an index exists in cache, then in most cases we
                 // will not be in this place (the data will be simply read from cache).
-                if (!this._parent._cacheClient.Store(StoreMode.Set, this._indexKeyInCache, this._index, this._parent._ttl))
+                if (!this._tableCache._cacheClient.SetValue(this._indexKeyInCache, this._index))
                 {
-                    this._parent._cacheClient.Remove(this._indexKeyInCache);
+                    this._tableCache._cacheClient.Remove(this._indexKeyInCache);
                     return false;
                 }
 
                 // (re)registering it in the list of indexes (it should be visible for update operations)
-                if (!this._parent.PutIndexToList(this._indexKey))
+                if (!this._tableCache.PutIndexToList(this._indexKey))
                 {
-                    this._parent._cacheClient.Remove(this._indexKeyInCache);
+                    this._tableCache._cacheClient.Remove(this._indexKeyInCache);
                     return false;
                 }
 
                 // remembering the index's current version
-                var casResult = this._parent._cacheClient.GetWithCas<TableIndex>(this._indexKeyInCache);
+                var casResult = this._tableCache._memcachedClient.GetWithCas<TableIndex>(this._indexKeyInCache);
                 if
                 (
                     (casResult.StatusCode != 0)
@@ -54,16 +51,16 @@ namespace Linq2DynamoDb.DataContext.Caching
                     (casResult.Result == null)
                 )
                 {
-                    this._parent._cacheClient.Remove(this._indexKeyInCache);
+                    this._tableCache._cacheClient.Remove(this._indexKeyInCache);
                     return false;
                 }
 
                 this._indexVersionInCache = casResult.Cas;
-                this._parent.Log("Index ({0}) was marked as being rebuilt", (object)this._indexKey);
+                this._tableCache.Log("Index ({0}) was marked as being rebuilt", (object)this._indexKey);
                 return true;
             }
 
-            public void AddEntityToIndex(EntityKey entityKey, Document doc)
+            public override void AddEntityToIndex(EntityKey entityKey, Document doc)
             {
                 // when creating a projection index, the entity key should not be passed
                 Debug.Assert(entityKey == null);
@@ -72,27 +69,27 @@ namespace Linq2DynamoDb.DataContext.Caching
                 this._index.AddEntity(doc);
             }
 
-            public void Dispose()
+            public override void Dispose()
             {
                 this._index.IsBeingRebuilt = false;
 
                 // saving the index to cache only if it's version didn't change since we started reading results from DynamoDb
-                var casResult = this._parent._cacheClient.Cas
+                var casResult = this._tableCache._memcachedClient.Cas
                 (
                     StoreMode.Replace, 
                     this._indexKeyInCache, 
                     this._index, 
-                    this._parent._ttl, 
+                    this._tableCache._cacheClient.DefaultTimeToLive, 
                     this._indexVersionInCache
                 );
 
                 if (casResult.Result)
                 {
-                    this._parent.Log("Index ({0}) with {1} entities saved to cache", (object)this._indexKey, this._index.Entities.Length);
+                    this._tableCache.Log("Index ({0}) with {1} entities saved to cache", (object)this._indexKey, this._index.Entities.Length);
                 }
                 else
                 {
-                    this._parent.Log("Index ({0}) wasn't saved to cache due to version conflict", (object)this._indexKey);
+                    this._tableCache.Log("Index ({0}) wasn't saved to cache due to version conflict", (object)this._indexKey);
                 }
             }
         }

--- a/Sources/Linq2DynamoDb.DataContext/Caching/EnyimTableCache.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/EnyimTableCache.cs
@@ -14,234 +14,34 @@ namespace Linq2DynamoDb.DataContext.Caching
     /// <summary>
     /// Implements caching in MemcacheD/ElastiCache via Enyim caching client
     /// </summary>
-    public partial class EnyimTableCache : ITableCache
+    public partial class EnyimTableCache : TableCache
     {
+		private MemcachedClient _memcachedClient
+		{
+			get { return (MemcachedClient) _cacheClient; }
+		}
         public EnyimTableCache(MemcachedClient cacheClient, TimeSpan cacheItemsTtl)
+			: base(new EnyimMemcachedClient(cacheClient, cacheItemsTtl))
         {
-            this._cacheClient = cacheClient;
-            this._ttl = cacheItemsTtl;
         }
+		public EnyimTableCache(EnyimMemcachedClient cacheClient)
+			: base(cacheClient)
+		{
+		}
 
         #region ITableCache implementation
 
-        public void Initialize(string tableName, Type tableEntityType, Primitive hashKeyValue)
+        public override void Initialize(string tableName, Type tableEntityType, Primitive hashKeyValue)
         {
-            if (this._tableEntityType != null)
-            {
-                throw new InvalidOperationException("An attempt to re-use an instance of EnyimTableCache for another <table>:<hash key> pair was made. This is not allowed");
-            }
+			base.Initialize(tableName, tableEntityType, hashKeyValue);
 
-            this._tableEntityType = tableEntityType;
-
-            this._tableName = tableName;
-            this._hashKeyValue = hashKeyValue == null ? string.Empty : hashKeyValue.AsString();
-
-            if (this.GetIndexListKeyInCache(this._hashKeyValue).Length > MaxKeyLength)
+            if (GetIndexListKeyInCache(_hashKeyValue).Length > MaxKeyLength)
             {
                 throw new ArgumentException("The hash key value is too long for MemcacheD. Cannot use cache with that value.");
             }
         }
 
-        public Document GetSingleEntity(EntityKey entityKey)
-        {
-            string entityKeyInCache = this.GetEntityKeyInCache(entityKey);
-            if (entityKeyInCache.Length > MaxKeyLength)
-            {
-                return null;
-            }
-
-            var wrapper = this._cacheClient.Get<CacheDocumentWrapper>(entityKeyInCache);
-            if (wrapper == null)
-            {
-                this.OnMiss.FireSafely();
-                return null;
-            }
-
-            this.OnHit.FireSafely();
-            return wrapper.Document;
-        }
-
-        public IEnumerable<Document> GetEntities(SearchConditions searchConditions, IEnumerable<string> projectedFields, string orderByFieldName, bool orderByDesc)
-        {
-            // first trying to find a full index
-            string indexKey = searchConditions.Key;
-            var index = this.TryLoadHealthyIndex(indexKey);
-
-            Document[] result = null;
-
-            // if no full index exist
-            if (index == null)
-            {
-                if (projectedFields != null)
-                {
-                    // then there still might be a projection index
-                    indexKey = this.GetProjectionIndexKey(searchConditions, projectedFields);
-                    result = this.TryLoadProjectionIndexEntities(indexKey);
-                }
-            }
-            else
-            {
-                result = this.TryLoadIndexEntities(index, indexKey);
-            }
-
-            // if we failed to load both full and projection index
-            if (result == null)
-            {
-                this.OnMiss.FireSafely();
-                return null;
-            }
-
-            this.OnHit.FireSafely();
-            this.Log("Index ({0}) with {1} items successfully loaded from cache", indexKey, result.Length);
-
-            if (string.IsNullOrEmpty(orderByFieldName))
-            {
-                return result;
-            }
-
-            // creating a comparer to sort the results
-            var comparer = PrimitiveComparer.GetComparer(this._tableEntityType, orderByFieldName);
-
-            return orderByDesc
-                ?
-                result.OrderByDescending(doc => doc[orderByFieldName].AsPrimitive(), comparer)
-                :
-                result.OrderBy(doc => doc[orderByFieldName].AsPrimitive(), comparer)
-            ;
-        }
-
-        public int? GetCount(SearchConditions searchConditions)
-        {
-            var index = this.TryLoadHealthyIndex(searchConditions.Key);
-
-            if (index == null)
-            {
-                this.OnMiss.FireSafely();
-                return null;
-            }
-
-            this.OnHit.FireSafely();
-            this.Log("Contents of index ({0}) successfully loaded from cache and number of items returned is {1}", searchConditions.Key, index.Count);
-
-            return index.Count;
-        }
-
-        public void PutSingleLoadedEntity(EntityKey entityKey, Document doc)
-        {
-            string entityKeyInCache = this.GetEntityKeyInCache(entityKey);
-            if (entityKeyInCache.Length > MaxKeyLength)
-            {
-                return;
-            }
-
-            // Putting the entity to cache, but only if it doesn't exist there.
-            // That's because when loading from DynamoDb whe should never overwrite local updates.
-            this._cacheClient.Store(StoreMode.Add, entityKeyInCache, new CacheDocumentWrapper(doc), this._ttl);
-        }
-
-        public void RemoveEntities(IEnumerable<EntityKey> entities)
-        {
-            var entityKeysInCache = entities
-                .Select(this.GetEntityKeyInCache)
-                // extracting too long keys
-                .Where(ek => ek.Length <= MaxKeyLength);
-
-            Parallel.ForEach(entityKeysInCache, key => this._cacheClient.Remove(key));
-        }
-
-        /// <summary>
-        /// Applies modifications to cached entities and indexes
-        /// </summary>
-        public void UpdateCacheAndIndexes(IDictionary<EntityKey, Document> addedEntities, IDictionary<EntityKey, Document> modifiedEntities, ICollection<EntityKey> removedEntities)
-        {
-            var allEntities = addedEntities
-                .Union(modifiedEntities)
-                .Union(removedEntities.ToDictionary(k => k, k => (Document)null))
-                // converting keys
-                .Select(kv => new KeyValuePair<string, Document>(this.GetEntityKeyInCache(kv.Key), kv.Value))
-                // extracting entities with too long keys
-                .Where(kv => kv.Key.Length <= MaxKeyLength)
-                .ToArray();
-
-            // modifying/removing all entities in parallel
-            var loopResult = Parallel.ForEach(allEntities, (entityPair, loopState) =>
-            {
-                bool result = true;
-                if (entityPair.Value == null)
-                {
-                    var removeResult = this._cacheClient.ExecuteRemove(entityPair.Key);
-                    if 
-                    (
-                        (removeResult.InnerResult != null)
-                        &&
-                        (removeResult.InnerResult.Exception != null)
-                    )
-                    {
-                        // this means, that item failed to be removed because of a communication error, not because the entity doesn't exist already
-                        result = false;
-                    }
-                }
-                else
-                {
-                    result = this._cacheClient.Store(StoreMode.Set, entityPair.Key, new CacheDocumentWrapper(entityPair.Value), this._ttl);
-                }
-
-                if (!result)
-                {
-                    loopState.Stop();
-                }
-            });
-
-            // All operations should succeed, otherwise removing all affected entities from cache.
-            // That's because in some cases partially succeded updates might become a problem.
-            if (!loopResult.IsCompleted)
-            {
-                this.Log("Failed to put updates for table {0} to cache", this._tableName);
-
-                Parallel.ForEach(allEntities, entityPair => this._cacheClient.Remove(entityPair.Key));
-                return;
-            }
-
-            // now updating indexes
-            this.UpdateIndexes(this._hashKeyValue, addedEntities, modifiedEntities, removedEntities);
-
-            // To support scenarios, when a context contains both a full table and a table filtered by a HashKey,
-            // by updating HashKey-filtered indexes we also should update indexes of the full table.
-            // And vice versa.
-
-            if (string.IsNullOrEmpty(this._hashKeyValue))
-            {
-                // Trying to update lists of indexes with predefined HashKey values
-                var affectedHashKeys = addedEntities
-                    .Where(kv => kv.Key.RangeKey != null)
-                    .Select(kv => kv.Key.HashKey.AsString())
-                    .Union
-                    (
-                        modifiedEntities
-                        .Where(kv => kv.Key.RangeKey != null)
-                        .Select(kv => kv.Key.HashKey.AsString())
-                    )
-                    .Union
-                    (
-                        removedEntities
-                        .Where(kv => kv.RangeKey != null)
-                        .Select(kv => kv.HashKey.AsString())
-                    )
-                    .Distinct();
-
-                foreach (var hashKeyValue in affectedHashKeys)
-                {
-                    this.UpdateIndexes(hashKeyValue, addedEntities, modifiedEntities, removedEntities);
-                }
-            }
-            else
-            {
-                // updating the full table indexes as well
-                this.UpdateIndexes(string.Empty, addedEntities, modifiedEntities, removedEntities);
-            }
-        }
-
-        public IIndexCreator StartCreatingIndex(SearchConditions searchConditions)
+        public override IIndexCreator StartCreatingIndex(SearchConditions searchConditions)
         {
             string indexKeyInCache = this.GetIndexKeyInCache(searchConditions.Key, this._hashKeyValue);
             if (indexKeyInCache.Length > MaxKeyLength)
@@ -250,18 +50,10 @@ namespace Linq2DynamoDb.DataContext.Caching
                 return null;
             }
 
-            var creator = new EnyimIndexCreator(this, indexKeyInCache, searchConditions);
-
-            if (!creator.StartCreatingIndex())
-            {
-                this.Log("Failed to start creating index ({0})", searchConditions.Key);
-                return null;
-            }
-
-            return creator;
+			return base.StartCreatingIndex<EnyimIndexCreator>(indexKeyInCache, searchConditions);
         }
 
-        public IIndexCreator StartCreatingProjectionIndex(SearchConditions searchConditions, IList<string> projectedFields)
+        public override IIndexCreator StartCreatingProjectionIndex(SearchConditions searchConditions, IList<string> projectedFields)
         {
             string indexKey = this.GetProjectionIndexKey(searchConditions, projectedFields);
             string indexKeyInCache = this.GetIndexKeyInCache(indexKey, this._hashKeyValue);
@@ -271,119 +63,11 @@ namespace Linq2DynamoDb.DataContext.Caching
                 return null;
             }
 
-            var creator = new EnyimProjectionIndexCreator(this, indexKey, indexKeyInCache, searchConditions);
-
-            if (!creator.StartCreatingIndex())
-            {
-                this.Log("Failed to start creating projection index ({0})", indexKey);
-                return null;
-            }
-
-            return creator;
+            return base.StartCreatingProjectionIndex<EnyimProjectionIndexCreator>(indexKey, indexKeyInCache, searchConditions);
         }
-
-        /// <summary>
-        /// Acquires a table-wide named lock and returns a disposable object, that represents it
-        /// </summary>
-        public IDisposable AcquireTableLock(string lockKey, TimeSpan lockTimeout)
-        {
-            return new TableLock(this, lockKey, lockTimeout);
-        }
-
-        public event Action OnHit;
-        public event Action OnMiss;
-        public event Action<string> OnLog;
-
-        #endregion
-
-        #region Public Methods
-
-        /// <summary>
-        /// Acquires a named lock around the table by storing a random value in cache
-        /// </summary>
-        internal void LockTable(string lockKey, TimeSpan lockTimeout)
-        {
-            if (this._lockIds.ContainsKey(lockKey))
-            {
-                throw new NotSupportedException("Recursive locks are not supported. Or maybe you're trying to use EnyimTableCache object from multiple threads?");
-            }
-
-            string cacheLockKey = this.GetLockKeyInCache(this._hashKeyValue, lockKey);
-            int cacheLockId = Rnd.Next();
-
-            var timeStart = DateTime.Now;
-            while (true)
-            {
-                if (DateTime.Now - timeStart > lockTimeout)
-                {
-                    break;
-                }
-
-                // Trying to create a new value in cache
-                if (this._cacheClient.Store(StoreMode.Add, cacheLockKey, cacheLockId))
-                {
-                    this._lockIds[lockKey] = cacheLockId;
-                    return;
-                }
-
-                Thread.Sleep(10);
-            }
-
-            // If we failed to acquire a lock within CacheLockTimeoutInSeconds 
-            // (this means, that another process crached), then we should forcibly acquire it
-
-            this.Log("Forcibly acquiring the table lock object {0} after {1} ms of waiting", lockKey, lockTimeout.TotalMilliseconds);
-
-            this._cacheClient.Store(StoreMode.Set, cacheLockKey, cacheLockId);
-            this._lockIds[lockKey] = cacheLockId;
-        }
-
-        /// <summary>
-        /// Releases a named lock around the table
-        /// </summary>
-        internal void UnlockTable(string lockKey)
-        {
-            int lockId;
-            if (!this._lockIds.TryRemove(lockKey, out lockId))
-            {
-                throw new InvalidOperationException
-                (
-                    string.Format("The table lock {0} wasn't acquired, so it cannot be released. Check your code!", lockKey)
-                );
-            }
-
-            string cacheLockKey = this.GetLockKeyInCache(this._hashKeyValue, lockKey);
-            var cacheLockId = this._cacheClient.Get(cacheLockKey);
-            if (cacheLockId == null)
-            {
-                // The cache miss might happen here, if a cache server crashed.
-                // In this case we just silently return.
-                this.Log("The table lock object {0} is missing in cache, but we don't care about that too much (probably, the cache node was restarted)", lockKey);
-                return;
-            }
-
-            if (((int)cacheLockId) != lockId)
-            {
-                // This means, that another process has forcibly replaced our lock.
-                throw new InvalidOperationException
-                (
-                    string.Format("The table lock {0} was forcibly acquired by another process", lockKey)
-                );
-            }
-
-            this._cacheClient.Remove(cacheLockKey);
-        }
-
         #endregion
 
         #region Private Properties
-
-        private readonly MemcachedClient _cacheClient;
-
-        /// <summary>
-        /// The time-to-live for all entities and indexes stored in cache
-        /// </summary>
-        private readonly TimeSpan _ttl;
 
         /// <summary>
         /// Entities and indexes with key longer than this limit are not saved to cache
@@ -391,134 +75,49 @@ namespace Linq2DynamoDb.DataContext.Caching
         private const int MaxKeyLength = 250;
 
         /// <summary>
-        /// Limit to the number of indexes
-        /// TODO: estimate this number more precisely
-        /// </summary>
-        private const int MaxNumberOfIndexes = 100;
-
-        /// <summary>
         /// The number of times to try an optimistic update operation
         /// </summary>
         private const int MaxUpdateAttempts = 10;
 
-        private Type _tableEntityType;
-
-        private string _tableName;
-        private string _hashKeyValue;
-
-        /// <summary>
-        /// Here all lock keys and their IDs are stored, for debugging purposes
-        /// </summary>
-        private readonly ConcurrentDictionary<string, int> _lockIds = new ConcurrentDictionary<string, int>();
-
-        private static readonly Random Rnd = new Random(DateTime.Now.Millisecond);
-
         #endregion
 
         #region Private Methods
+		protected override string GetEntityKeyInCache(EntityKey entityKey)
+		{
+			string entityKeyInCache = base.GetEntityKeyInCache(entityKey);
+			if (entityKeyInCache.Length > MaxKeyLength)
+			{
+				return null;
+			}
+			return entityKeyInCache;
+		}
+		protected override string[] GetEntityKeysInCache(IEnumerable<EntityKey> entities)
+		{
+			var entityKeysInCache = entities
+				.Select(this.GetEntityKeyInCache)
+				// extracting too long keys
+				.Where(ek => ek.Length <= MaxKeyLength)
+				.ToArray();
+			return entityKeysInCache;
+		}
+		protected override KeyValuePair<string, Document>[] CombineEntityDictionaries(params IDictionary<EntityKey, Document>[] entities)
+		{
+			var allEntities = base.CombineEntityDictionaries(entities);
+			allEntities = allEntities
+				// extracting entities with too long keys
+				.Where(kv => kv.Key.Length <= MaxKeyLength)
+				.ToArray();
+			return allEntities;
+		}
 
-        private const string ProjectionIndexKeyPrefix = "[proj]";
-
-        /// <summary>
-        /// Composes a key for a projection index
-        /// </summary>
-        private string GetProjectionIndexKey(SearchConditions searchConditions, IEnumerable<string> projectedFields)
-        {
-            return ProjectionIndexKeyPrefix + projectedFields.Aggregate((i, s) => i + "," + s) + "; " + searchConditions.Key;
-        }
-
-        /// <summary>
-        /// Checks if the provided key is a projection index's key
-        /// </summary>
-        private bool IsProjectionIndex(string indexKey)
-        {
-            return indexKey.StartsWith(ProjectionIndexKeyPrefix);
-        }
-
-        /// <summary>
-        /// Gets a cache key for an entity
-        /// </summary>
-        private string GetEntityKeyInCache(EntityKey entityKey)
-        {
-            // entities will always be identified in cache by their key prefixed by table name.
-            // entityKey might contain spaces, which are not allowed for MemcacheD keys. This is why ToBase64() is used.
-            return (this._tableName + ":" + entityKey).ToBase64();
-        }
-
-        /// <summary>
-        /// Gets a cache key for an index
-        /// </summary>
-        private string GetIndexKeyInCache(string indexKey, string hashKeyValue)
-        {
-            // indexKey might contain spaces, which are not allowed for MemcacheD keys
-            return (this._tableName + hashKeyValue + indexKey).ToBase64();
-        }
-
-        /// <summary>
-        /// Gets a cache key for the list of all indexes
-        /// </summary>
-        private string GetIndexListKeyInCache(string hashKeyValue)
-        {
-            return (this._tableName + hashKeyValue + ":indexes").ToBase64();
-        }
-
-        /// <summary>
-        /// Gets a cache key for a table-wide lock
-        /// </summary>
-        private string GetLockKeyInCache(string lockKey, string hashKeyValue)
-        {
-            return (this._tableName + hashKeyValue + lockKey).ToBase64();
-        }
-
-        /// <summary>
-        /// Adds matching entities and removes removed entities from indexes
-        /// </summary>
-        private void UpdateIndexes(string hashKeyValue, IDictionary<EntityKey, Document> addedEntities, IDictionary<EntityKey, Document> modifiedEntities, ICollection<EntityKey> removedEntities)
-        {
-            string indexListKeyInCache = this.GetIndexListKeyInCache(hashKeyValue);
-
-            var indexes = this._cacheClient.Get<TableIndexList>(indexListKeyInCache);
-            if (indexes == null)
-            {
-                this._cacheClient.Remove(indexListKeyInCache);
-                return;
-            }
-
-            // storing indexes, that fail to be updated
-            var indexesToBeRemoved = new ConcurrentDictionary<string, string>();
-
-            Parallel.ForEach(indexes, indexKey =>
-            {
-                string indexKeyInCache = this.GetIndexKeyInCache(indexKey, hashKeyValue);
-
-                bool indexUpdateSucceeded = 
-                    this.IsProjectionIndex(indexKey) 
-                    ? 
-                    this.UpdateProjectionIndex(indexKey, indexKeyInCache, addedEntities, modifiedEntities, removedEntities) 
-                    : 
-                    this.UpdateIndex(indexKey, indexKeyInCache, addedEntities, removedEntities);
-
-                if (!indexUpdateSucceeded)
-                {
-                    indexesToBeRemoved[indexKey] = indexKeyInCache;
-                }
-            });
-
-            // removing bad indexes
-            if (indexesToBeRemoved.Count > 0)
-            {
-                this.RemoveIndexesFromList(indexesToBeRemoved, indexListKeyInCache);
-            }
-        }
-
-        /// <summary>
+		/// <summary>
         /// Adds matching entities and removes removed entities from an index
         /// </summary>
-        private bool UpdateIndex(string indexKey, string indexKeyInCache, IDictionary<EntityKey, Document> addedEntities, ICollection<EntityKey> removedEntities)
+        protected override bool UpdateIndex(string indexKey, string indexKeyInCache, IDictionary<EntityKey, Document> addedEntities, ICollection<EntityKey> removedEntities)
         {
             for (int i = 0; i < MaxUpdateAttempts; i++)
             {
-                var indexGetResult = this._cacheClient.GetWithCas<TableIndex>(indexKeyInCache);
+                var indexGetResult = _memcachedClient.GetWithCas<TableIndex>(indexKeyInCache);
                 var index = indexGetResult.Result;
                 if (index == null)
                 {
@@ -561,7 +160,7 @@ namespace Linq2DynamoDb.DataContext.Caching
                     return true;
                 }
 
-                if (this._cacheClient.Cas(StoreMode.Set, indexKeyInCache, index, this._ttl, indexGetResult.Cas).Result)
+                if (_memcachedClient.Cas(StoreMode.Set, indexKeyInCache, index, _cacheClient.DefaultTimeToLive, indexGetResult.Cas).Result)
                 {
                     this.Log("Index ({0}) updated. {1} entities added, {2} entities removed", indexKey, addedEntities.Count, removedEntities.Count);
                     return true;
@@ -573,7 +172,7 @@ namespace Linq2DynamoDb.DataContext.Caching
         /// <summary>
         /// Checks if a projection index should be dropped because of some added/modified/removed entities
         /// </summary>
-        private bool UpdateProjectionIndex(string indexKey, string indexKeyInCache, IDictionary<EntityKey, Document> addedEntities, IDictionary<EntityKey, Document> modifiedEntities, ICollection<EntityKey> removedEntities)
+        protected override bool UpdateProjectionIndex(string indexKey, string indexKeyInCache, IDictionary<EntityKey, Document> addedEntities, IDictionary<EntityKey, Document> modifiedEntities, ICollection<EntityKey> removedEntities)
         {
             // if some entities were modified or removed
             if 
@@ -588,7 +187,7 @@ namespace Linq2DynamoDb.DataContext.Caching
                 return false;
             }
 
-            var indexGetResult = this._cacheClient.GetWithCas<TableProjectionIndex>(indexKeyInCache);
+            var indexGetResult = _memcachedClient.GetWithCas<TableProjectionIndex>(indexKeyInCache);
             var index = indexGetResult.Result;
             if (index == null)
             {
@@ -620,14 +219,14 @@ namespace Linq2DynamoDb.DataContext.Caching
             return true;
         }
 
-        private bool PutIndexToList(string indexKey)
+        protected override bool PutIndexToList(string indexKey)
         {
             string indexListKeyInCache = this.GetIndexListKeyInCache(this._hashKeyValue);
 
             // trying multiple times
             for (int i = 0; i < MaxUpdateAttempts; i++)
             {
-                var indexesGetResult = this._cacheClient.GetWithCas<TableIndexList>(indexListKeyInCache);
+                var indexesGetResult = _memcachedClient.GetWithCas<TableIndexList>(indexListKeyInCache);
 
                 if (indexesGetResult.StatusCode != 0)
                 {
@@ -649,7 +248,7 @@ namespace Linq2DynamoDb.DataContext.Caching
                     this.Log("An old index ({0}) was removed from cache because the number of supported indexes ({1}) is exceeded", poppedIndexKey, MaxNumberOfIndexes);
                 }
 
-                if (this._cacheClient.Cas(StoreMode.Set, indexListKeyInCache, indexes, this._ttl, indexesGetResult.Cas).Result)
+                if (_memcachedClient.Cas(StoreMode.Set, indexListKeyInCache, indexes, _cacheClient.DefaultTimeToLive, indexesGetResult.Cas).Result)
                 {
                     return true;
                 }
@@ -659,7 +258,7 @@ namespace Linq2DynamoDb.DataContext.Caching
             return false;
         }
 
-        private void RemoveIndexFromList(string indexKey, string indexKeyInCache, string indexListKeyInCache)
+        protected override void RemoveIndexFromList(string indexKey, string indexKeyInCache, string indexListKeyInCache)
         {
             // always removing the index itself
             this._cacheClient.Remove(indexKeyInCache);
@@ -667,7 +266,7 @@ namespace Linq2DynamoDb.DataContext.Caching
             // trying multiple times
             for (int i = 0; i < MaxUpdateAttempts; i++)
             {
-                var indexesGetResult = this._cacheClient.GetWithCas<TableIndexList>(indexListKeyInCache);
+                var indexesGetResult = _memcachedClient.GetWithCas<TableIndexList>(indexListKeyInCache);
 
                 if (indexesGetResult.StatusCode != 0)
                 {
@@ -691,7 +290,7 @@ namespace Linq2DynamoDb.DataContext.Caching
 
                 indexes.Remove(indexKey);
 
-                var casResult = this._cacheClient.Cas(StoreMode.Set, indexListKeyInCache, indexes, this._ttl, indexesGetResult.Cas);
+                var casResult = _memcachedClient.Cas(StoreMode.Set, indexListKeyInCache, indexes, _cacheClient.DefaultTimeToLive, indexesGetResult.Cas);
                 if (casResult.Result)
                 {
                     return;
@@ -702,7 +301,7 @@ namespace Linq2DynamoDb.DataContext.Caching
             this._cacheClient.Remove(indexListKeyInCache);
         }
 
-        private void RemoveIndexesFromList(IDictionary<string, string> indexKeys, string indexListKeyInCache)
+        protected override void RemoveIndexesFromList(IDictionary<string, string> indexKeys, string indexListKeyInCache)
         {
             // always removing indexes themselves
             Parallel.ForEach(indexKeys.Values, indexKeyInCache => this._cacheClient.Remove(indexKeyInCache));
@@ -711,7 +310,7 @@ namespace Linq2DynamoDb.DataContext.Caching
             //TODO: implement a helper for multiple attempts
             for (int i = 0; i < MaxUpdateAttempts; i++)
             {
-                var indexesGetResult = this._cacheClient.GetWithCas<TableIndexList>(indexListKeyInCache);
+                var indexesGetResult = _memcachedClient.GetWithCas<TableIndexList>(indexListKeyInCache);
 
                 if (indexesGetResult.StatusCode != 0)
                 {
@@ -743,7 +342,7 @@ namespace Linq2DynamoDb.DataContext.Caching
                     return;
                 }
 
-                var casResult = this._cacheClient.Cas(StoreMode.Set, indexListKeyInCache, indexes, this._ttl, indexesGetResult.Cas);
+                var casResult = _memcachedClient.Cas(StoreMode.Set, indexListKeyInCache, indexes, _cacheClient.DefaultTimeToLive, indexesGetResult.Cas);
                 if (casResult.Result)
                 {
                     return;
@@ -753,133 +352,6 @@ namespace Linq2DynamoDb.DataContext.Caching
             this.Log("Failed to remove {0} indexes from list after {1} attempts. Removing the whole list.", indexKeys.Count, MaxUpdateAttempts);
             this._cacheClient.Remove(indexListKeyInCache);
         }
-
-        /// <summary>
-        /// Loads the index by it's key, ensuring everything
-        /// </summary>
-        private HashSet<EntityKey> TryLoadHealthyIndex(string indexKey)
-        {
-            string indexKeyInCache = this.GetIndexKeyInCache(indexKey, this._hashKeyValue);
-            if (indexKeyInCache.Length > MaxKeyLength)
-            {
-                return null;
-            }
-
-            // first trying to get the index from cache
-            var index = this._cacheClient.Get<TableIndex>(indexKeyInCache);
-            if (index == null)
-            {
-                return null;
-            }
-
-            // Checking, that index is mentioned in the list of indexes.
-            // Only indexes from list are updated with local updates.
-            if (!this.DoesIndexExistInTheListOfIndexes(indexKey))
-            {
-                this._cacheClient.Remove(indexKeyInCache);
-                return null;
-            }
-
-            // If index is currently being filled with data from DynamoDb, then we can't use it yet
-            if (index.IsBeingRebuilt)
-            {
-                return null;
-            }
-
-            return index.Index;
-        }
-
-        /// <summary>
-        /// Loads a projection index by it's key
-        /// </summary>
-        private Document[] TryLoadProjectionIndexEntities(string indexKey)
-        {
-            string indexKeyInCache = this.GetIndexKeyInCache(indexKey, this._hashKeyValue);
-            if (indexKeyInCache.Length > MaxKeyLength)
-            {
-                return null;
-            }
-
-            // first trying to get the index from cache
-            var index = this._cacheClient.Get<TableProjectionIndex>(indexKeyInCache);
-            if (index == null)
-            {
-                return null;
-            }
-
-            // Checking, that index is mentioned in the list of indexes.
-            // Only indexes from list are updated with local updates.
-            if (!this.DoesIndexExistInTheListOfIndexes(indexKey))
-            {
-                this._cacheClient.Remove(indexKeyInCache);
-                return null;
-            }
-
-            // If index is currently being filled with data from DynamoDb, then we can't use it yet
-            if (index.IsBeingRebuilt)
-            {
-                return null;
-            }
-
-            return index.Entities;
-        }
-
-        private Document[] TryLoadIndexEntities(HashSet<EntityKey> entityKeys, string indexKey)
-        {
-            var result = new Document[entityKeys.Count];
-
-            // now we have to succeed loading all entities from cache
-            var loopResult = Parallel.ForEach(entityKeys, (entityKey, loopState, i) =>
-            {
-                var wrapper = this._cacheClient.Get<CacheDocumentWrapper>(this.GetEntityKeyInCache(entityKey));
-                if (wrapper == null)
-                {
-                    loopState.Stop();
-                    return;
-                }
-
-                result[i] = wrapper.Document;
-            });
-
-            if (loopResult.IsCompleted)
-            {
-                return result;
-            }
-
-            this.Log("Failed to get contents of index ({0}) from cache", indexKey);
-
-            // the index is not usable any more, we'd better delete it
-            this.RemoveIndexFromList
-            (
-                indexKey,
-                this.GetIndexKeyInCache(indexKey, this._hashKeyValue),
-                this.GetIndexListKeyInCache(this._hashKeyValue)
-            );
-            return null;
-        }
-
-        private bool DoesIndexExistInTheListOfIndexes(string indexKey)
-        {
-            var indexList = this._cacheClient.Get<TableIndexList>(this.GetIndexListKeyInCache(this._hashKeyValue));
-            return ((indexList != null) && (indexList.Contains(indexKey)));
-        }
-
-        internal void Log(string format, params object[] args)
-        {
-            var handler = this.OnLog;
-            if (handler == null)
-            {
-                return;
-            }
-            string tableName = this._tableName;
-            if (!string.IsNullOrEmpty(this._hashKeyValue))
-            {
-                tableName += ":" + this._hashKeyValue;
-            }
-
-            handler("EnyimTableCache(" + tableName + ") : " + string.Format(format, args));
-        }
-
         #endregion
     }
 }

--- a/Sources/Linq2DynamoDb.DataContext/Caching/ICacheClient.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/ICacheClient.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Linq2DynamoDb.DataContext.Caching
+{
+	public interface ICacheClient
+	{
+		TimeSpan DefaultTimeToLive { get; set; }
+		//TValue this[string key] { get; set; }
+
+		//TValue this[string key, DateTime expiration] { set; }
+		//TValue this[string key, TimeSpan? timeToLive] { set; }
+
+		bool Remove(string key);
+		bool TryRemove(string key);
+
+		bool TryGetValue<TValue>(string key, out TValue value);
+		//bool TryGetValue<TValue>(string key, out TValue value, out TimeSpan? timeToLive);
+		//bool TryGetValue<TValue>(string key, out TValue value, out DateTime? expiration);
+		//bool TryGetTimeToLive(string key, out TimeSpan? timetoLive);
+
+		bool AddValue<TValue>(string key, TValue value);
+		bool AddValue<TValue>(string key, TValue value, TimeSpan? timeToLive);
+		bool AddValue<TValue>(string key, TValue value, DateTime? expiration);
+		bool SetValue<TValue>(string key, TValue value);
+		bool SetValue<TValue>(string key, TValue value, TimeSpan? timeToLive);
+		bool SetValue<TValue>(string key, TValue value, DateTime? expiration);
+
+		bool ReplaceValue<TValue>(string key, TValue value);
+		bool ReplaceValue<TValue>(string key, TValue value, TimeSpan? timeToLive);
+		bool ReplaceValue<TValue>(string key, TValue value, DateTime? expiration);
+
+		//bool SetTimeToLive(string key, TimeSpan? timetoLive);
+	}
+
+	//public interface ICacheClient : ICacheClient<string, string>
+	//{
+	//}
+}

--- a/Sources/Linq2DynamoDb.DataContext/Caching/IIndexCreator.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/IIndexCreator.cs
@@ -10,5 +10,6 @@ namespace Linq2DynamoDb.DataContext.Caching
     public interface IIndexCreator : IDisposable
     {
         void AddEntityToIndex(EntityKey entityKey, Document doc);
+		bool StartCreatingIndex();
     }
 }

--- a/Sources/Linq2DynamoDb.DataContext/Caching/IndexCreator.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/IndexCreator.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DocumentModel;
+
+namespace Linq2DynamoDb.DataContext.Caching
+{
+	public abstract partial class TableCache
+	{
+		protected class IndexCreator : IIndexCreator
+		{
+			protected readonly TableCache _parent;
+			protected TableIndex _index;
+			protected readonly string _indexKey;
+			protected readonly string _indexKeyInCache;
+
+			internal IndexCreator(TableCache parent, string indexKeyInCache, SearchConditions searchConditions)
+			{
+				_parent = parent;
+				_index = new TableIndex(searchConditions);
+				_indexKey = searchConditions.Key;
+				_indexKeyInCache = indexKeyInCache;
+			}
+
+			public virtual bool StartCreatingIndex()
+			{
+				// Marking the index as being rebuilt.
+				// Note: we're using Set mode. This means, that if an index exists in cache, it will be 
+				// overwritten. That's OK, because if an index exists in cache, then in most cases we
+				// will not be in this place (the data will be simply read from cache).
+				_parent._cacheClient.SetValue(_indexKeyInCache, _index);
+
+				// (re)registering it in the list of indexes (it should be visible for update operations)
+				if (!this._parent.PutIndexToList(_indexKey))
+				{
+					_parent._cacheClient.Remove(_indexKeyInCache);
+					return false;
+				}
+
+				_parent.Log("Index ({0}) was marked as being rebuilt", _indexKey);
+				return true;
+			}
+
+			public virtual void AddEntityToIndex(EntityKey entityKey, Document doc)
+			{
+				string key = _parent.GetEntityKeyInCache(entityKey);
+
+				// adding key to index (it's essential to do this _before_ checking the key length - the index should fail to be read next time)
+				_index.Index.Add(entityKey);
+
+				// Putting the entity to cache, but only if it doesn't exist there.
+				// That's because when loading from DynamoDb whe should never overwrite local updates.
+				_parent._cacheClient.SetValue(key, new CacheDocumentWrapper(doc));
+			}
+
+			public virtual void Dispose()
+			{
+				if (this._index == null)
+				{
+					_parent._cacheClient.Remove(_indexKeyInCache);
+					return;
+				}
+
+				this._index.IsBeingRebuilt = false;
+
+				// saving the index to cache
+				_parent._cacheClient.ReplaceValue(_indexKeyInCache, _index);
+				_parent.Log("Index ({0}) with {1} entities saved to cache", _indexKey, _index.Index.Count);
+			}
+		}
+	}
+}

--- a/Sources/Linq2DynamoDb.DataContext/Caching/ProjectionIndexCreator.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/ProjectionIndexCreator.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DocumentModel;
+
+namespace Linq2DynamoDb.DataContext.Caching
+{
+	public abstract partial class TableCache
+	{
+		protected class ProjectionIndexCreator : IIndexCreator
+		{
+			protected readonly TableCache _parent;
+
+			protected readonly TableProjectionIndex _index;
+			protected readonly string _indexKey;
+			protected readonly string _indexKeyInCache;
+
+			internal ProjectionIndexCreator(TableCache parent, string indexKey, string indexKeyInCache, SearchConditions searchConditions)
+			{
+				this._parent = parent;
+				this._index = new TableProjectionIndex(searchConditions);
+				this._indexKey = indexKey;
+				this._indexKeyInCache = indexKeyInCache;
+			}
+
+			public virtual bool StartCreatingIndex()
+			{
+				// Marking the index as being rebuilt.
+				// Note: we're using Set mode. This means, that if an index exists in cache, it will be 
+				// overwritten. That's OK, because if an index exists in cache, then in most cases we
+				// will not be in this place (the data will be simply read from cache).
+				_parent._cacheClient.SetValue(_indexKeyInCache, _index);
+
+				// (re)registering it in the list of indexes (it should be visible for update operations)
+				if (!this._parent.PutIndexToList(this._indexKey))
+				{
+					this._parent._cacheClient.Remove(this._indexKeyInCache);
+					return false;
+				}
+
+				this._parent.Log("Index ({0}) was marked as being rebuilt", (object) this._indexKey);
+				return true;
+			}
+
+			public virtual void AddEntityToIndex(EntityKey entityKey, Document doc)
+			{
+				// adding document to index
+				this._index.AddEntity(doc);
+			}
+
+			public virtual void Dispose()
+			{
+				this._index.IsBeingRebuilt = false;
+
+				// saving the index to cache only if its version didn't change since we started reading results from DynamoDb
+				_parent._cacheClient.ReplaceValue(_indexKeyInCache, _index);
+				this._parent.Log("Index ({0}) with {1} entities saved to cache", (object) this._indexKey, this._index.Entities.Length);
+			}
+		}
+	}
+}

--- a/Sources/Linq2DynamoDb.DataContext/Caching/RedisCacheClient.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/RedisCacheClient.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Linq2DynamoDb.DataContext.Utils;
+using StackExchange.Redis;
+
+namespace Linq2DynamoDb.DataContext.Caching
+{
+	public class RedisCacheClient : ICacheClient
+	{
+		private static readonly object s_syncObject = new object();
+		private static IConnectionMultiplexer s_singConnectionMultiplexer;
+
+		private static readonly Lazy<IConnectionMultiplexer> s_connectionMultiplexer = new Lazy<IConnectionMultiplexer>(ConnectToCluster);
+
+		private static string[] s_initialRegistrationCallChain;
+
+		private static IConnectionMultiplexer Multiplexer
+		{
+			get { return s_connectionMultiplexer.Value; }
+		}
+
+		private static IConnectionMultiplexer ConnectToCluster()
+		{
+			lock (s_syncObject)
+			{
+				if (s_singConnectionMultiplexer != null)
+					throw new ApplicationException(
+						string.Format(
+							"Already connected to cluster. Connection established, object created, been there, done that. Initial call made through call chain: {0}",
+							string.Join(", ", s_initialRegistrationCallChain)));
+
+				s_initialRegistrationCallChain = (new StackTrace()
+					.GetFrames() ?? new StackFrame[] { })
+					.Select(x => x.GetMethod())
+					.Select(x => x.Name)
+					.Reverse()
+					.ToArray();
+
+				return s_singConnectionMultiplexer = ConnectionMultiplexer.Connect(RedisServer);
+			}
+		}
+
+		public static string RedisServer { get; set; }
+		public TimeSpan DefaultTimeToLive { get; set; }
+
+		public RedisCacheClient(string connectionString, TimeSpan? ttl)
+		{
+			RedisServer = connectionString;
+			DefaultTimeToLive = ttl ?? TimeSpan.FromMinutes(15);
+		}
+
+		public bool Remove(string key)
+		{
+			IDatabase db = Multiplexer.GetDatabase();
+			return db.KeyDelete(key);
+		}
+		public bool TryRemove(string key)
+		{
+			try
+			{
+				return Remove(key);
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
+		public bool TryGetValue<T>(string key, out T value)
+		{
+			value = default(T);
+
+			IDatabase db = Multiplexer.GetDatabase();
+			var returnValue = db.StringGet(key);
+
+			if (!returnValue.HasValue)
+				return false;
+
+			Base64Serializer<T> serializer = new Base64Serializer<T>();
+			value = serializer.Deserialize(returnValue);
+			return true;
+		}
+
+		public bool AddValue<T>(string key, T value)
+		{
+			string existing;
+			if (TryGetValue(key, out existing))
+				throw new ArgumentException(string.Format("Key '{0}' already exists in database", key));
+
+			return SetValue(key, value);
+		}
+
+		public bool AddValue<T>(string key, T value, TimeSpan? timeToLive)
+		{
+			string existing;
+			if (TryGetValue(key, out existing))
+				throw new ArgumentException(string.Format("Key '{0}' already exists in database", key));
+
+			return SetValue(key, value, timeToLive);
+		}
+
+		public bool AddValue<T>(string key, T value, DateTime? expiration)
+		{
+			string existing;
+			if (TryGetValue(key, out existing))
+				throw new ArgumentException(string.Format("Key '{0}' already exists in database", key));
+
+			return SetValue(key, value, expiration);
+		}
+
+		public bool SetValue<T>(string key, T value)
+		{
+			IDatabase db = Multiplexer.GetDatabase();
+			Base64Serializer<T> serializer = new Base64Serializer<T>();
+			string serialized = serializer.Serialize(value);
+			return db.StringSet(key, serialized);
+		}
+
+		public bool SetValue<T>(string key, T value, TimeSpan? timeToLive)
+		{
+			IDatabase db = Multiplexer.GetDatabase();
+			Base64Serializer<T> serializer = new Base64Serializer<T>();
+			string serialized = serializer.Serialize(value);
+			return db.StringSet(key, serialized, timeToLive);
+		}
+
+		public bool SetValue<T>(string key, T value, DateTime? expiration)
+		{
+			var timeToLive = expiration == null
+				? null
+				: expiration - DateTime.UtcNow;
+
+			return SetValue(key, value, timeToLive);
+		}
+		public bool ReplaceValue<T>(string key, T value)
+		{
+			string existing;
+			if (!TryGetValue(key, out existing))
+				throw new KeyNotFoundException(string.Format("Key '{0}' not found in database", key));
+
+			return SetValue(key, value);
+		}
+		public bool ReplaceValue<T>(string key, T value, TimeSpan? timeToLive)
+		{
+			string existing;
+			if (!TryGetValue(key, out existing))
+				throw new KeyNotFoundException(string.Format("Key '{0}' not found in database", key));
+
+			return SetValue(key, value, timeToLive);
+		}
+		public bool ReplaceValue<T>(string key, T value, DateTime? expiration)
+		{
+			string existing;
+			if (!TryGetValue(key, out existing))
+				throw new KeyNotFoundException(string.Format("Key '{0}' not found in database", key));
+
+			return SetValue(key, value, expiration);
+		}
+	}
+}

--- a/Sources/Linq2DynamoDb.DataContext/Caching/RedisTableCache.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/RedisTableCache.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Linq2DynamoDb.DataContext.Caching
+{
+	public class RedisTableCache : TableCache
+	{
+		public RedisTableCache(RedisCacheClient client)
+			: base(client)
+		{
+		}
+	}
+}

--- a/Sources/Linq2DynamoDb.DataContext/Caching/TableCache.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/TableCache.cs
@@ -1,0 +1,761 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DocumentModel;
+using Linq2DynamoDb.DataContext.Utils;
+
+namespace Linq2DynamoDb.DataContext.Caching
+{
+	public abstract partial class TableCache : ITableCache
+	{
+		protected Type _tableEntityType;
+		protected string _tableName;
+		protected string _hashKeyValue;
+		protected ICacheClient _cacheClient;
+        protected const string ProjectionIndexKeyPrefix = "[proj]";
+
+		/// <summary>
+		/// Limit to the number of indexes
+		/// TODO: estimate this number more precisely
+		/// </summary>
+		protected const int MaxNumberOfIndexes = 100;
+
+		/// <summary>
+		/// Here all lock keys and their IDs are stored, for debugging purposes
+		/// </summary>
+		private readonly ConcurrentDictionary<string, int> _lockIds = new ConcurrentDictionary<string, int>();
+		private static readonly Random Rnd = new Random(DateTime.Now.Millisecond);
+
+		protected TableCache(ICacheClient client)
+		{
+			_cacheClient = client;
+		}
+
+		#region ITableCache implementation
+		public event Action OnHit;
+		public event Action<string> OnLog;
+		public event Action OnMiss;
+
+		public virtual void Initialize(string tableName, Type tableEntityType, Primitive hashKeyValue)
+		{
+			if (this._tableEntityType != null)
+			{
+				throw new InvalidOperationException("An attempt to re-use an instance of TableCache for another <table>:<hash key> pair was made. This is not allowed");
+			}
+
+			this._tableEntityType = tableEntityType;
+
+			this._tableName = tableName;
+			this._hashKeyValue = hashKeyValue == null ? string.Empty : hashKeyValue.AsString();
+		}
+
+		public virtual Document GetSingleEntity(EntityKey entityKey)
+		{
+			string entityKeyInCache = this.GetEntityKeyInCache(entityKey);
+			if (entityKeyInCache == null)
+				return null;
+
+			CacheDocumentWrapper wrapper;
+			if (!_cacheClient.TryGetValue<CacheDocumentWrapper>(entityKeyInCache, out wrapper))
+			{
+				this.OnMiss.FireSafely();
+				return null;
+			}
+
+			this.OnHit.FireSafely();
+			return wrapper.Document;
+		}
+
+		public virtual IEnumerable<Document> GetEntities(SearchConditions searchConditions, IEnumerable<string> projectedFields, string orderByFieldName, bool orderByDesc)
+		{
+			// first trying to find a full index
+			string indexKey = searchConditions.Key;
+			HashSet<EntityKey> index = this.TryLoadHealthyIndex(indexKey);
+
+			Document[] result = null;
+
+			// if no full index exist
+			if (index == null)
+			{
+				if (projectedFields != null)
+				{
+					// then there still might be a projection index
+					indexKey = this.GetProjectionIndexKey(searchConditions, projectedFields);
+					result = this.TryLoadProjectionIndexEntities(indexKey);
+				}
+			}
+			else
+			{
+				result = this.TryLoadIndexEntities(index, indexKey);
+			}
+
+			// if we failed to load both full and projection index
+			if (result == null)
+			{
+				this.OnMiss.FireSafely();
+				return null;
+			}
+
+			this.OnHit.FireSafely();
+			this.Log("Index ({0}) with {1} items successfully loaded from cache", indexKey, result.Length);
+
+			if (string.IsNullOrEmpty(orderByFieldName))
+			{
+				return result;
+			}
+
+			// creating a comparer to sort the results
+			var comparer = PrimitiveComparer.GetComparer(this._tableEntityType, orderByFieldName);
+
+			return orderByDesc
+				?
+				result.OrderByDescending(doc => doc[orderByFieldName].AsPrimitive(), comparer)
+				:
+				result.OrderBy(doc => doc[orderByFieldName].AsPrimitive(), comparer)
+			;
+		}
+
+		public int? GetCount(SearchConditions searchConditions)
+		{
+			HashSet<EntityKey> index = this.TryLoadHealthyIndex(searchConditions.Key);
+
+			if (index == null)
+			{
+				this.OnMiss.FireSafely();
+				return null;
+			}
+
+			this.OnHit.FireSafely();
+			this.Log("Contents of index ({0}) successfully loaded from cache and number of items returned is {1}", searchConditions.Key, index.Count);
+
+			return index.Count;
+		}
+
+		public void PutSingleLoadedEntity(EntityKey entityKey, Document doc)
+		{
+			string entityKeyInCache = this.GetEntityKeyInCache(entityKey);
+			if (entityKeyInCache == null)
+				return;
+
+			// Putting the entity to cache, but only if it doesn't exist there.
+			// That's because when loading from DynamoDb whe should never overwrite local updates.
+			this._cacheClient.AddValue(entityKeyInCache, new CacheDocumentWrapper(doc));
+		}
+
+		public virtual void RemoveEntities(IEnumerable<EntityKey> entities)
+		{
+			var entityKeysInCache = entities
+				.Select(this.GetEntityKeyInCache);
+
+			Parallel.ForEach(entityKeysInCache, key => this._cacheClient.Remove(key));
+		}
+
+		/// <summary>
+		/// Applies modifications to cached entities and indexes
+		/// </summary>
+		public virtual void UpdateCacheAndIndexes(IDictionary<EntityKey, Document> addedEntities, IDictionary<EntityKey, Document> modifiedEntities, ICollection<EntityKey> removedEntities)
+		{
+			var allEntities = CombineEntityDictionaries(addedEntities, modifiedEntities, removedEntities.ToDictionary(k => k, k => (Document) null));
+
+			// modifying/removing all entities in parallel
+			var loopResult = Parallel.ForEach(allEntities, (entityPair, loopState) =>
+			{
+				bool result = true;
+				if (entityPair.Value == null)
+				{
+					result = this._cacheClient.TryRemove(entityPair.Key);
+				}
+				else
+				{
+					result = this._cacheClient.SetValue(entityPair.Key, new CacheDocumentWrapper(entityPair.Value));
+				}
+
+				if (!result)
+				{
+					loopState.Stop();
+				}
+			});
+
+			// All operations should succeed, otherwise removing all affected entities from cache.
+			// That's because in some cases partially succeded updates might become a problem.
+			if (!loopResult.IsCompleted)
+			{
+				this.Log("Failed to put updates for table {0} to cache", this._tableName);
+
+				Parallel.ForEach(allEntities, entityPair => this._cacheClient.Remove(entityPair.Key));
+				return;
+			}
+
+			// now updating indexes
+			this.UpdateIndexes(this._hashKeyValue, addedEntities, modifiedEntities, removedEntities);
+
+			// To support scenarios, when a context contains both a full table and a table filtered by a HashKey,
+			// by updating HashKey-filtered indexes we also should update indexes of the full table.
+			// And vice versa.
+
+			if (string.IsNullOrEmpty(this._hashKeyValue))
+			{
+				// Trying to update lists of indexes with predefined HashKey values
+				var affectedHashKeys = addedEntities
+					.Where(kv => kv.Key.RangeKey != null)
+					.Select(kv => kv.Key.HashKey.AsString())
+					.Union
+					(
+						modifiedEntities
+						.Where(kv => kv.Key.RangeKey != null)
+						.Select(kv => kv.Key.HashKey.AsString())
+					)
+					.Union
+					(
+						removedEntities
+						.Where(kv => kv.RangeKey != null)
+						.Select(kv => kv.HashKey.AsString())
+					)
+					.Distinct();
+
+				foreach (var hashKeyValue in affectedHashKeys)
+				{
+					this.UpdateIndexes(hashKeyValue, addedEntities, modifiedEntities, removedEntities);
+				}
+			}
+			else
+			{
+				// updating the full table indexes as well
+				this.UpdateIndexes(string.Empty, addedEntities, modifiedEntities, removedEntities);
+			}
+		}
+
+		public virtual IIndexCreator StartCreatingIndex(SearchConditions searchConditions) 
+		{
+			string indexKeyInCache = this.GetIndexKeyInCache(searchConditions.Key, this._hashKeyValue);
+			return StartCreatingIndex<IndexCreator>(indexKeyInCache, searchConditions);
+		}
+
+		protected T StartCreatingIndex<T>(string indexKeyInCache, SearchConditions searchConditions) 
+			where T : IIndexCreator
+		{
+			T creator = (T) Activator.CreateInstance(typeof(T), this, indexKeyInCache, searchConditions);
+
+			if (!creator.StartCreatingIndex())
+			{
+				this.Log("Failed to start creating index ({0})", searchConditions.Key);
+				return default(T);
+			}
+
+			return creator;
+		}
+
+		public virtual IIndexCreator StartCreatingProjectionIndex(SearchConditions searchConditions, IList<string> projectedFields)
+		{
+			string indexKey = this.GetProjectionIndexKey(searchConditions, projectedFields);
+			string indexKeyInCache = this.GetIndexKeyInCache(indexKey, this._hashKeyValue);
+			return StartCreatingProjectionIndex<ProjectionIndexCreator>(indexKey, indexKeyInCache, searchConditions);
+		}
+
+		protected T StartCreatingProjectionIndex<T>(string indexKey, string indexKeyInCache, SearchConditions searchConditions)
+			where T : IIndexCreator
+		{
+			T creator = (T) Activator.CreateInstance(typeof(T), this, indexKey, indexKeyInCache, searchConditions);
+
+			if (!creator.StartCreatingIndex())
+			{
+				this.Log("Failed to start creating projection index ({0})", indexKey);
+				return default(T);
+			}
+
+			return creator;
+		}
+
+		/// <summary>
+		/// Acquires a table-wide named lock and returns a disposable object, that represents it
+		/// </summary>
+		public IDisposable AcquireTableLock(string lockKey, TimeSpan lockTimeout)
+		{
+			return new TableLock(this, lockKey, lockTimeout);
+		}
+		/// <summary>
+		/// Acquires a named lock around the table by storing a random value in cache
+		/// </summary>
+		internal void LockTable(string lockKey, TimeSpan lockTimeout)
+		{
+			if (this._lockIds.ContainsKey(lockKey))
+			{
+				throw new NotSupportedException("Recursive locks are not supported. Or maybe you're trying to use EnyimTableCache object from multiple threads?");
+			}
+
+			string cacheLockKey = this.GetLockKeyInCache(this._hashKeyValue, lockKey);
+			int cacheLockId = Rnd.Next();
+
+			var timeStart = DateTime.Now;
+			while (true)
+			{
+				if (DateTime.Now - timeStart > lockTimeout)
+				{
+					break;
+				}
+
+				// Trying to create a new value in cache
+				if (this._cacheClient.AddValue(cacheLockKey, cacheLockId))
+				{
+					this._lockIds[lockKey] = cacheLockId;
+					return;
+				}
+
+				Thread.Sleep(10);
+			}
+
+			// If we failed to acquire a lock within CacheLockTimeoutInSeconds 
+			// (this means, that another process crached), then we should forcibly acquire it
+
+			this.Log("Forcibly acquiring the table lock object {0} after {1} ms of waiting", lockKey, lockTimeout.TotalMilliseconds);
+
+			this._cacheClient.SetValue(cacheLockKey, cacheLockId);
+			this._lockIds[lockKey] = cacheLockId;
+		}
+
+		/// <summary>
+		/// Releases a named lock around the table
+		/// </summary>
+		internal void UnlockTable(string lockKey)
+		{
+			int lockId;
+			if (!this._lockIds.TryRemove(lockKey, out lockId))
+			{
+				throw new InvalidOperationException
+				(
+					string.Format("The table lock {0} wasn't acquired, so it cannot be released. Check your code!", lockKey)
+				);
+			}
+
+			string cacheLockKey = this.GetLockKeyInCache(this._hashKeyValue, lockKey);
+			int cacheLockId;
+			if (!_cacheClient.TryGetValue(cacheLockKey, out cacheLockId))
+			{
+				// The cache miss might happen here, if a cache server crashed.
+				// In this case we just silently return.
+				this.Log("The table lock object {0} is missing in cache, but we don't care about that too much (probably, the cache node was restarted)", lockKey);
+				return;
+			}
+
+			if (cacheLockId != lockId)
+			{
+				// This means, that another process has forcibly replaced our lock.
+				throw new InvalidOperationException
+				(
+					string.Format("The table lock {0} was forcibly acquired by another process", lockKey)
+				);
+			}
+
+			this._cacheClient.Remove(cacheLockKey);
+		}
+		#endregion
+
+		#region Cache key methods
+		/// <summary>
+		/// Gets a cache key for an entity
+		/// </summary>
+		protected virtual string GetEntityKeyInCache(EntityKey entityKey)
+		{
+			return string.Format("{0}:{1}", _tableName, entityKey);
+		}
+
+		protected virtual string[] GetEntityKeysInCache(IEnumerable<EntityKey> entities)
+		{
+            string[] entityKeysInCache = entities
+                .Select(this.GetEntityKeyInCache).ToArray();
+			return entityKeysInCache;
+		}
+
+		protected virtual KeyValuePair<string, Document>[] CombineEntityDictionaries(params IDictionary<EntityKey, Document>[] entities)
+		{
+			IEnumerable<KeyValuePair<EntityKey, Document>> allEntities = new Dictionary<EntityKey, Document>(entities.Sum(x => x.Count));
+			bool first = true;
+			foreach (var item in entities)
+			{
+				allEntities = allEntities.Union(item);
+			}
+			return allEntities.Select(kv => new KeyValuePair<string, Document>(this.GetEntityKeyInCache(kv.Key), kv.Value)).ToArray();
+		}
+
+		/// <summary>
+		/// Gets a cache key for an index. Returns null if the key is invalid for any reason.
+		/// </summary>
+		protected string GetIndexKeyInCache(string indexKey, string hashKeyValue)
+		{
+			return string.Format("{0}{1}{2}", _tableName, hashKeyValue, indexKey).ToBase64();
+		}
+
+		/// <summary>
+		/// Gets a cache key for the list of all indexes
+		/// </summary>
+		protected string GetIndexListKeyInCache(string hashKeyValue)
+		{
+			return string.Format("{0}{1}:indexes", _tableName, hashKeyValue).ToBase64();
+		}
+
+		/// <summary>
+		/// Gets a cache key for a table-wide lock
+		/// </summary>
+		protected string GetLockKeyInCache(string lockKey, string hashKeyValue)
+		{
+			return string.Format("{0}{1}{2}", _tableName, hashKeyValue, lockKey).ToBase64();
+		}
+
+		/// <summary>
+		/// Composes a key for a projection index
+		/// </summary>
+		protected string GetProjectionIndexKey(SearchConditions searchConditions, IEnumerable<string> projectedFields)
+		{
+			return string.Format("{0}{1}; {2}",
+				ProjectionIndexKeyPrefix,
+				projectedFields.Aggregate((i, s) => string.Format("{0},{1}", i, s)),
+				searchConditions.Key);
+		}
+		#endregion
+
+		#region Index-related methods
+		/// <summary>
+		/// Loads the index by its key, ensuring everything
+		/// </summary>
+		protected HashSet<EntityKey> TryLoadHealthyIndex(string indexKey)
+		{
+			string indexKeyInCache = this.GetIndexKeyInCache(indexKey, this._hashKeyValue);
+
+			// first trying to get the index from cache
+			TableIndex index;
+			if (!_cacheClient.TryGetValue(indexKeyInCache, out index))
+			{
+				return null;
+			}
+
+			// Checking, that index is mentioned in the list of indexes.
+			// Only indexes from list are updated with local updates.
+			if (!DoesIndexExistInTheListOfIndexes(indexKey))
+			{
+				_cacheClient.Remove(indexKeyInCache);
+				return null;
+			}
+
+			// If index is currently being filled with data from DynamoDb, then we can't use it yet
+			if (index.IsBeingRebuilt)
+			{
+				return null;
+			}
+
+			return index.Index;
+		}
+
+		/// <summary>
+		/// Loads a projection index by its key
+		/// </summary>
+		protected Document[] TryLoadProjectionIndexEntities(string indexKey)
+		{
+			string indexKeyInCache = this.GetIndexKeyInCache(indexKey, this._hashKeyValue);
+			if (indexKeyInCache == null)
+			{
+				return null;
+			}
+
+			// first trying to get the index from cache
+			TableProjectionIndex index;
+			if (!_cacheClient.TryGetValue(indexKeyInCache, out index))
+			{
+				return null;
+			}
+
+			// Checking, that index is mentioned in the list of indexes.
+			// Only indexes from list are updated with local updates.
+			if (!this.DoesIndexExistInTheListOfIndexes(indexKey))
+			{
+				this._cacheClient.Remove(indexKeyInCache);
+				return null;
+			}
+
+			// If index is currently being filled with data from DynamoDb, then we can't use it yet
+			if (index.IsBeingRebuilt)
+			{
+				return null;
+			}
+
+			return index.Entities;
+		}
+
+		private Document[] TryLoadIndexEntities(HashSet<EntityKey> entityKeys, string indexKey)
+		{
+			var result = new Document[entityKeys.Count];
+
+			// now we have to succeed loading all entities from cache
+			var loopResult = Parallel.ForEach(entityKeys, (entityKey, loopState, i) =>
+			{
+				CacheDocumentWrapper wrapper;
+				string entityKeyInCache = GetEntityKeyInCache(entityKey);
+				if (!_cacheClient.TryGetValue(entityKeyInCache, out wrapper))
+				{
+					loopState.Stop();
+					return;
+				}
+
+				result[i] = wrapper.Document;
+			});
+
+			if (loopResult.IsCompleted)
+			{
+				return result;
+			}
+
+			this.Log("Failed to get contents of index ({0}) from cache", indexKey);
+
+			// the index is not usable any more, we'd better delete it
+			this.RemoveIndexFromList
+			(
+				indexKey,
+				this.GetIndexKeyInCache(indexKey, this._hashKeyValue),
+				this.GetIndexListKeyInCache(this._hashKeyValue)
+			);
+			return null;
+		}
+
+		protected bool DoesIndexExistInTheListOfIndexes(string indexKey)
+		{
+			TableIndexList indexList;
+			_cacheClient.TryGetValue(GetIndexListKeyInCache(_hashKeyValue), out indexList);
+			return ((indexList != null) && (indexList.Contains(indexKey)));
+		}
+
+		/// <summary>
+		/// Adds matching entities and removes removed entities from indexes
+		/// </summary>
+		protected virtual void UpdateIndexes(string hashKeyValue, IDictionary<EntityKey, Document> addedEntities, IDictionary<EntityKey, Document> modifiedEntities, ICollection<EntityKey> removedEntities)
+		{
+			string indexListKeyInCache = this.GetIndexListKeyInCache(hashKeyValue);
+
+			TableIndexList indexes;
+			if (!_cacheClient.TryGetValue<TableIndexList>(indexListKeyInCache, out indexes))
+			{
+				_cacheClient.Remove(indexListKeyInCache);
+				return;
+			}
+
+			// storing indexes, that fail to be updated
+			var indexesToBeRemoved = new ConcurrentDictionary<string, string>();
+
+			Parallel.ForEach(indexes, indexKey =>
+			{
+				string indexKeyInCache = this.GetIndexKeyInCache(indexKey, hashKeyValue);
+
+				bool indexUpdateSucceeded =
+					this.IsProjectionIndex(indexKey)
+					?
+					this.UpdateProjectionIndex(indexKey, indexKeyInCache, addedEntities, modifiedEntities, removedEntities)
+					:
+					this.UpdateIndex(indexKey, indexKeyInCache, addedEntities, removedEntities);
+
+				if (!indexUpdateSucceeded)
+				{
+					indexesToBeRemoved[indexKey] = indexKeyInCache;
+				}
+			});
+
+			// removing bad indexes
+			if (indexesToBeRemoved.Count > 0)
+			{
+				this.RemoveIndexesFromList(indexesToBeRemoved, indexListKeyInCache);
+			}
+		}
+
+		/// <summary>
+		/// Adds matching entities and removes removed entities from an index
+		/// </summary>
+		protected virtual bool UpdateIndex(string indexKey, string indexKeyInCache, IDictionary<EntityKey, Document> addedEntities, ICollection<EntityKey> removedEntities)
+		{
+			TableIndex index;
+			if (!_cacheClient.TryGetValue(indexKeyInCache, out index))
+			{
+				return false;
+			}
+
+			bool indexChanged = false;
+
+			try
+			{
+				// adding added entities, if they match the index conditions
+				foreach
+				(
+					var entityPair in addedEntities.Where
+					(
+						entityPair => index.MatchesSearchConditions(entityPair.Value, this._tableEntityType)
+					)
+				)
+				{
+					index.Index.Add(entityPair.Key);
+					indexChanged = true;
+				}
+			}
+			catch (Exception ex)
+			{
+				// some stupid exceptions might occur within TableIndex.MatchesSearchConditions()
+				this.Log("Failed to update index ({0}) because of the following exception: {1}", indexKey, ex);
+				return false;
+			}
+
+			// removing removed entities
+			foreach (var entityKey in removedEntities.Where(entityKey => index.Index.Contains(entityKey)))
+			{
+				index.Index.Remove(entityKey);
+				indexChanged = true;
+			}
+
+			if (!indexChanged)
+			{
+				return true;
+			}
+
+			_cacheClient.SetValue(indexKeyInCache, index);
+			this.Log("Index ({0}) updated. {1} entities added, {2} entities removed", indexKey, addedEntities.Count, removedEntities.Count);
+			return true;
+		}
+
+		/// <summary>
+		/// Checks if a projection index should be dropped because of some added/modified/removed entities
+		/// </summary>
+		protected virtual bool UpdateProjectionIndex(string indexKey, string indexKeyInCache, IDictionary<EntityKey, Document> addedEntities, IDictionary<EntityKey, Document> modifiedEntities, ICollection<EntityKey> removedEntities)
+		{
+			// if some entities were modified or removed
+			if
+			(
+				(modifiedEntities.Count > 0)
+				||
+				(removedEntities.Count > 0)
+			)
+			{
+				// then the only option for us is to drop the index - as we don't know, if these entities conform to index's conditions or not
+				this.Log("Projection index ({0}) removed because some entities were removed", indexKey);
+				return false;
+			}
+
+			TableProjectionIndex index;
+			if (!_cacheClient.TryGetValue(indexKeyInCache, out index))
+			{
+				return false;
+			}
+
+			try
+			{
+				// if any added or modified entities conform to index's conditions
+				if
+				(
+					addedEntities.Values.Any
+					(
+						en => index.MatchesSearchConditions(en, this._tableEntityType)
+					)
+				)
+				{
+					this.Log("Projection index ({0}) removed because of some added entities", indexKey);
+					return false;
+				}
+			}
+			catch (Exception ex)
+			{
+				// some stupid exceptions might occur within TableIndex.MatchesSearchConditions()
+				this.Log("Failed to check projection index ({0}) because of the following exception: {1}", indexKey, ex);
+				return false;
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// Checks if the provided key is a projection index's key
+		/// </summary>
+		protected bool IsProjectionIndex(string indexKey)
+		{
+			return indexKey.StartsWith(ProjectionIndexKeyPrefix);
+		}
+
+		protected virtual bool PutIndexToList(string indexKey)
+		{
+			string indexListKeyInCache = this.GetIndexListKeyInCache(this._hashKeyValue);
+
+			TableIndexList indexes;
+			if (!_cacheClient.TryGetValue(indexListKeyInCache, out indexes))
+				indexes = new TableIndexList(MaxNumberOfIndexes);
+
+			if (indexes.Contains(indexKey))
+			{
+				return true;
+			}
+
+			string poppedIndexKey = indexes.Push(indexKey);
+			if (poppedIndexKey != null)
+			{
+				// if an older index was removed from the list during push operation - then removing it from cache
+				this._cacheClient.Remove(this.GetIndexKeyInCache(poppedIndexKey, this._hashKeyValue));
+				this.Log("An old index ({0}) was removed from cache because the number of supported indexes ({1}) is exceeded", poppedIndexKey, MaxNumberOfIndexes);
+			}
+
+			try
+			{
+				_cacheClient.SetValue(indexListKeyInCache, indexes);
+				return true;
+			}
+			catch 
+			{
+				return false;
+			}
+		}
+
+		protected virtual void RemoveIndexFromList(string indexKey, string indexKeyInCache, string indexListKeyInCache)
+		{
+			// always removing the index itself
+			_cacheClient.Remove(indexKeyInCache);
+
+			TableIndexList indexes;
+			if (!_cacheClient.TryGetValue(indexListKeyInCache, out indexes))
+				return;
+
+			indexes.Remove(indexKey);
+
+			// store updated index list
+			_cacheClient.ReplaceValue(indexListKeyInCache, indexes);
+		}
+
+		protected virtual void RemoveIndexesFromList(IDictionary<string, string> indexKeys, string indexListKeyInCache)
+		{
+			// always removing indexes themselves
+			Parallel.ForEach(indexKeys.Values, indexKeyInCache => this._cacheClient.Remove(indexKeyInCache));
+
+			TableIndexList indexes;
+			if (!_cacheClient.TryGetValue(indexListKeyInCache, out indexes))
+				return;
+
+			foreach (KeyValuePair<string, string> pair in indexKeys)
+			{
+				indexes.Remove(pair.Value);
+			}
+
+			// store updated index list
+			_cacheClient.ReplaceValue(indexListKeyInCache, indexes);
+		}
+		#endregion
+
+		internal void Log(string format, params object[] args)
+		{
+			var handler = this.OnLog;
+			if (handler == null)
+			{
+				return;
+			}
+			string tableName = this._tableName;
+			if (!string.IsNullOrEmpty(this._hashKeyValue))
+			{
+				tableName = string.Format("{0}:{1}", tableName, this._hashKeyValue);
+			}
+
+			handler(string.Format("TableCache({0}) : ", tableName, string.Format(format, args)));
+		}
+	}
+}

--- a/Sources/Linq2DynamoDb.DataContext/Caching/TableLock.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Caching/TableLock.cs
@@ -7,11 +7,11 @@ namespace Linq2DynamoDb.DataContext.Caching
     /// </summary>
     internal class TableLock : IDisposable
     {
-        private readonly EnyimTableCache _cache;
+        private readonly TableCache _cache;
         private readonly string _lockKey;
         private bool _disposed;
 
-        internal TableLock(EnyimTableCache repository, string lockKey, TimeSpan lockTimeout)
+        internal TableLock(TableCache repository, string lockKey, TimeSpan lockTimeout)
         {
             this._cache = repository;
             this._lockKey = lockKey;

--- a/Sources/Linq2DynamoDb.DataContext/Linq2DynamoDb.DataContext.csproj
+++ b/Sources/Linq2DynamoDb.DataContext/Linq2DynamoDb.DataContext.csproj
@@ -48,6 +48,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EnyimMemcached.2.12\lib\net35\Enyim.Caching.dll</HintPath>
     </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.0.488\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
@@ -65,7 +69,17 @@
     <Compile Include="Caching\CacheDocumentWrapper.cs" />
     <Compile Include="Caching\CacheDynamoDbEntryWrapper.cs" />
     <Compile Include="Caching\CachePrimitiveWrapper.cs" />
+    <Compile Include="Caching\EnyimMemcachedClient.cs" />
     <Compile Include="Caching\EnyimProjectionIndexCreator.cs" />
+    <Compile Include="Caching\EnyimTableCache.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Caching\ICacheClient.cs" />
+    <Compile Include="Caching\IndexCreator.cs" />
+    <Compile Include="Caching\ProjectionIndexCreator.cs" />
+    <Compile Include="Caching\RedisCacheClient.cs" />
+    <Compile Include="Caching\RedisTableCache.cs" />
+    <Compile Include="Caching\TableCache.cs" />
     <Compile Include="Caching\TableLock.cs" />
     <Compile Include="Caching\TableProjectionIndex.cs" />
     <Compile Include="CreateTableArgs.cs" />
@@ -89,7 +103,6 @@
     <Compile Include="EntityProxy.cs" />
     <Compile Include="EntityWrapper.cs" />
     <Compile Include="Caching\EnyimIndexCreator.cs" />
-    <Compile Include="Caching\EnyimTableCache.cs" />
     <Compile Include="ExpressionUtils\ColumnProjectionResult.cs" />
     <Compile Include="ExpressionUtils\ProjectionVisitor.cs" />
     <Compile Include="ExpressionUtils\SubtreeEvaluationVisitor.cs" />
@@ -111,6 +124,7 @@
     <Compile Include="Caching\TableIndex.cs" />
     <Compile Include="Caching\TableIndexList.cs" />
     <Compile Include="TableDefinitionWrapperBase.cs" />
+    <Compile Include="Utils\Base64Serializer.cs" />
     <Compile Include="Utils\TranslationResultUtils.cs" />
     <Compile Include="Utils\DynamoDbConversionUtils.cs" />
     <Compile Include="Utils\GeneralUtils.cs" />

--- a/Sources/Linq2DynamoDb.DataContext/Utils/Base64Serializer.cs
+++ b/Sources/Linq2DynamoDb.DataContext/Utils/Base64Serializer.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace Linq2DynamoDb.DataContext.Utils
+{
+	public class Base64Serializer<T>
+	{
+		public string Serialize(T obj)
+		{
+			byte[] bytes = SerializeToBytes(obj);
+			return Convert.ToBase64String(bytes);
+		}
+
+		public T Deserialize(string text)
+		{
+			byte[] bytes = Convert.FromBase64String(text);
+			return DeserializeBytes(bytes);
+		}
+
+		public static byte[] SerializeToBytes(T obj)
+		{
+			using (MemoryStream memoryStream = new MemoryStream())
+			{
+				BinaryFormatter serializer = new BinaryFormatter();
+				serializer.Serialize(memoryStream, obj);
+				return memoryStream.ToArray();
+			}
+		}
+
+		public static T DeserializeBytes(byte[] bytes)
+		{
+			using (MemoryStream memoryStream = new MemoryStream(bytes))
+			{
+				BinaryFormatter serializer = new BinaryFormatter();
+				memoryStream.Seek(0, SeekOrigin.Begin);
+				return (T) serializer.Deserialize(memoryStream);
+			}
+		}
+	}
+}

--- a/Sources/Linq2DynamoDb.DataContext/packages.config
+++ b/Sources/Linq2DynamoDb.DataContext/packages.config
@@ -3,4 +3,5 @@
   <package id="AWSSDK.Core" version="3.1.1.0" targetFramework="net45" />
   <package id="AWSSDK.DynamoDBv2" version="3.1.0.1" targetFramework="net45" />
   <package id="EnyimMemcached" version="2.12" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.488" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
NOTE: I am unable to test this code as written because I don't have local instances of Memcached or Redis. Sorry. However, I did port the code I wrote for work, and it's operational there.

- Created a base TableCache class that now contains most of the logic from EnyimTableCache. Likewise, created base IndexCreator and ProjectionIndexCreator classes.
- Decoupled the actual cache provider from the TableCache class by creating an ICacheClient interface
- EnyimTableCache now only overrides the base class for things are that specific to Memcached (key lengths, using CAS)

Hopefully I didn't mess it up too badly. :)
