### PR TITLE
Fix #33

### DIFF
--- a/Sources/Linq2DynamoDb.DataContext.Tests/DataContextTestBase.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/DataContextTestBase.cs
@@ -14,12 +14,14 @@ namespace Linq2DynamoDb.DataContext.Tests
         public static void ClassInit()
         {
             BooksHelper.StartSession();
+            BookPocosHelper.StartSession();
         }
 
         [TestFixtureTearDown]
         public static void ClassClean()
         {
             BooksHelper.CleanSession();
+            BookPocosHelper.CleanSession();
         }
 
         [SetUp]

--- a/Sources/Linq2DynamoDb.DataContext.Tests/Entities/BookPoco.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/Entities/BookPoco.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+
+namespace Linq2DynamoDb.DataContext.Tests.Entities {
+    [DynamoDBTable("BookPoco")]
+    public class BookPoco {
+        [DynamoDBHashKey]
+        public string Name { get; set; }
+
+        [DynamoDBRangeKey]
+        public int PublishYear { get; set; }
+
+        public int NumPages { get; set; }
+
+        public string Author { get; set; }
+
+        [DynamoDBProperty(typeof(PopularityConverter))]
+        public Popularity PopularityRating { get; set; }
+
+        [DynamoDBProperty(typeof(StarsConverter))]
+        public Stars UserFeedbackRating { get; set; }
+
+        public List<string> RentingHistory { get; set; }
+
+        public DateTime LastRentTime { get; set; }
+
+        [DynamoDBProperty(typeof(StringTimeSpanDictionaryConverter))]
+        public IDictionary<string, TimeSpan> FilmsBasedOnBook { get; set; }
+
+        public enum Popularity {
+            Low,
+
+            BelowAverage,
+
+            Average,
+
+            AboveAverage,
+
+            High
+        }
+
+        public enum Stars {
+            None = 0,
+            Bronze = 1,
+            Silver = 2,
+            Gold = 3,
+            Platinum = 4,
+            Diamond = 5
+        }
+
+        private class PopularityConverter : IPropertyConverter {
+            public DynamoDBEntry ToEntry(object value) {
+                return new Primitive(value.ToString());
+            }
+
+            public object FromEntry(DynamoDBEntry entry) {
+                return Enum.Parse(typeof(Popularity), entry.AsString());
+            }
+        }
+
+        private class StarsConverter : IPropertyConverter {
+            public DynamoDBEntry ToEntry(object value) {
+                var enumValue = (int)value;
+                return new Primitive(enumValue.ToString(CultureInfo.InvariantCulture), true);
+            }
+
+            public object FromEntry(DynamoDBEntry entry) {
+                return Enum.Parse(typeof(Stars), entry.AsString());
+            }
+        }
+
+        private class StringTimeSpanDictionaryConverter : IPropertyConverter {
+            public DynamoDBEntry ToEntry(object value) {
+                if (value == null) {
+                    return null;
+                }
+
+                var dictionary = (IDictionary<string, TimeSpan>)value;
+                var primitiveList = new PrimitiveList(DynamoDBEntryType.String);
+                foreach (var keyValuePair in dictionary) {
+                    primitiveList.Add(new Primitive(string.Format("{0}@{1}", keyValuePair.Key, keyValuePair.Value)));
+                }
+
+                return primitiveList;
+            }
+
+            public object FromEntry(DynamoDBEntry entry) {
+                if (entry == null) {
+                    return null;
+                }
+
+                var list = entry.AsListOfString();
+                var dictionary = new Dictionary<string, TimeSpan>();
+                foreach (var record in list) {
+                    var split = record.Split('@');
+
+                    var key = split[0];
+                    var value = TimeSpan.Parse(split[1]);
+
+                    dictionary.Add(key, value);
+                }
+
+                return dictionary;
+            }
+        }
+
+        public class PublisherDto {
+            public string Title { get; set; }
+            public string Address { get; set; }
+
+            public override string ToString() {
+                return this.Title + this.Address;
+            }
+        }
+
+        public PublisherDto Publisher { get; set; }
+
+        public class ReviewDto {
+            public string Author { get; set; }
+            public string Text { get; set; }
+
+            public override string ToString() {
+                return this.Author + this.Text;
+            }
+        }
+
+        public List<ReviewDto> ReviewsList { get; set; }
+    }
+}

--- a/Sources/Linq2DynamoDb.DataContext.Tests/EntityManagementTests/EntityModificationTests.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/EntityManagementTests/EntityModificationTests.cs
@@ -1,6 +1,7 @@
 ﻿using Linq2DynamoDb.DataContext.Tests.Entities;
 using Linq2DynamoDb.DataContext.Tests.Helpers;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace Linq2DynamoDb.DataContext.Tests.EntityManagementTests
 {
@@ -30,6 +31,24 @@ namespace Linq2DynamoDb.DataContext.Tests.EntityManagementTests
 
             var storedBook = booksTable.Find(book.Name, book.PublishYear);
             Assert.AreEqual(book.PopularityRating, storedBook.PopularityRating, "Record was not updated");
+        }
+
+        [Test]
+        public void DataContext_EntityModification_UpdateRecordWithNewArray() 
+        {
+            var book = BooksHelper.CreateBook(rentingHistory: null, persistToDynamoDb: false);
+            var booksTable = this.Context.GetTable<Book>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            var storedBook = booksTable.Find(book.Name, book.PublishYear);
+
+            storedBook.RentingHistory = new List<string>() { "non-empty array" };
+            this.Context.SubmitChanges();
+
+            var storedBookAfterModification = booksTable.Find(book.Name, book.PublishYear);
+            
+            CollectionAssert.AreEquivalent(storedBook.RentingHistory, storedBookAfterModification.RentingHistory);
         }
 
         [Ignore("This behavior is currently expected. SubmitChanges() uses DocumentBatchWrite, which only supports PUT operations with default 'replace' behavior")]

--- a/Sources/Linq2DynamoDb.DataContext.Tests/EntityManagementTests/Poco/PocoCreationTests.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/EntityManagementTests/Poco/PocoCreationTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using Linq2DynamoDb.DataContext.Tests.Entities;
+using Linq2DynamoDb.DataContext.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Linq2DynamoDb.DataContext.Tests.EntityManagementTests.Poco
+{
+    [TestFixture]
+    public class PocoCreationTests : DataContextTestBase
+    {
+        public override void SetUp()
+        {
+            this.Context = TestConfiguration.GetDataContext();
+        }
+
+        public override void TearDown()
+        {
+        }
+
+        [Test]
+        public void DataContext_EntityCreation_PersistsRecordToDynamoDb()
+        {
+            var book = BookPocosHelper.CreateBookPoco(persistToDynamoDb: false);
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            var storedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+            Assert.IsNotNull(storedBookPoco);
+        }
+
+        [Ignore("This behavior is currently expected. SubmitChanges() uses DocumentBatchWrite, which only supports PUT operations, which by default replaces existing entities")]
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException), ExpectedMessage = "cannot be added, because entity with that key already exists", MatchType = MessageMatch.Contains)]
+        public void DataContext_EntityCreation_ThrowsExceptionWhenEntityAlreadyExistsInDynamoDbButWasNeverQueriedInCurrentContext()
+        {
+            var book = BookPocosHelper.CreateBookPoco(popularityRating: BookPoco.Popularity.Average);
+
+            book.PopularityRating = BookPoco.Popularity.High;
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException), ExpectedMessage = "cannot be added, because entity with that key already exists", MatchType = MessageMatch.Contains)]
+        public void DataContext_EntityCreation_ThrowsExceptionWhenTryingToAddSameEntityTwice()
+        {
+            var book = BookPocosHelper.CreateBookPoco(popularityRating: BookPoco.Popularity.Average, persistToDynamoDb: false);
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            book.PopularityRating = BookPoco.Popularity.High;
+
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException), ExpectedMessage = "cannot be added, because entity with that key already exists", MatchType = MessageMatch.Contains)]
+        public void DataContext_EntityCreation_ThrowsExceptionWhenEntityPreviouslyStoredInDynamoDbWasQueriedInCurrentContext()
+        {
+            var book = BookPocosHelper.CreateBookPoco(popularityRating: BookPoco.Popularity.Average);
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.Find(book.Name, book.PublishYear);
+
+            book.PopularityRating = BookPoco.Popularity.High;
+
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+        }
+
+        [Test]
+        public void DataContext_EntityCreation_StoresComplexObjectProperties()
+        {
+            var book = BookPocosHelper.CreateBookPoco(persistToDynamoDb: false, publisher: new BookPoco.PublisherDto { Title = "O’Reilly Media", Address = "Sebastopol, CA" });
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            var storedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+            Assert.AreEqual(book.Publisher.ToString(), storedBookPoco.Publisher.ToString(), "Complex object properties are not equal");
+
+            storedBookPoco.Publisher = new BookPoco.PublisherDto { Title = "O’Reilly Media", Address = "Illoqortormiut, Greenland" };
+
+            this.Context.SubmitChanges();
+
+            var storedBookPoco2 = booksTable.Find(book.Name, book.PublishYear);
+
+            Assert.AreEqual(storedBookPoco2.Publisher.ToString(), storedBookPoco.Publisher.ToString(), "Complex object properties are not equal after updating");
+        }
+
+
+        [Test]
+        public void DataContext_EntityCreation_StoresComplexObjectListProperties()
+        {
+            var book = BookPocosHelper.CreateBookPoco(persistToDynamoDb: false, reviews: new List<BookPoco.ReviewDto> { new BookPoco.ReviewDto { Author = "Beavis", Text = "Cool" }, new BookPoco.ReviewDto { Author = "Butt-head", Text = "This sucks!" } });
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            var storedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+
+            var expectedSequence1 = string.Join(", ", book.ReviewsList.Select(r => r.ToString()).OrderBy(s => s));
+            var actualSequence1 = string.Join(", ", storedBookPoco.ReviewsList.Select(r => r.ToString()).OrderBy(s => s));
+            Assert.AreEqual(expectedSequence1, actualSequence1, "Complex object list properties are not equal");
+        }
+
+    }
+}

--- a/Sources/Linq2DynamoDb.DataContext.Tests/EntityManagementTests/Poco/PocoModificationTests.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/EntityManagementTests/Poco/PocoModificationTests.cs
@@ -1,0 +1,104 @@
+﻿using Linq2DynamoDb.DataContext.Tests.Entities;
+using Linq2DynamoDb.DataContext.Tests.Helpers;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Linq2DynamoDb.DataContext.Tests.EntityManagementTests.Poco
+{
+    [TestFixture]
+    public class PocoModificationTests : DataContextTestBase
+    {
+        public override void SetUp()
+        {
+            this.Context = TestConfiguration.GetDataContext();
+        }
+
+        public override void TearDown()
+        {
+        }
+
+        [Test]
+        public void DataContext_EntityModification_UpdatesRecordWithNewValues()
+        {
+            var book = BookPocosHelper.CreateBookPoco(popularityRating: BookPoco.Popularity.Average, persistToDynamoDb: false);
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            book.PopularityRating = BookPoco.Popularity.High;
+            this.Context.SubmitChanges();
+
+            var storedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+            Assert.AreEqual(book.PopularityRating, storedBookPoco.PopularityRating, "Record was not updated");
+        }
+
+        [Test]
+        public void DataContext_EntityModification_UpdateRecordWithNewArray()
+        {
+            var book = BookPocosHelper.CreateBookPoco(rentingHistory: null, persistToDynamoDb: false);
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            var storedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+
+            storedBookPoco.RentingHistory = new List<string>() { "non-empty array" };
+            this.Context.SubmitChanges();
+
+            var storedBookPocoAfterModification = booksTable.Find(book.Name, book.PublishYear);
+
+            CollectionAssert.AreEquivalent(storedBookPoco.RentingHistory, storedBookPocoAfterModification.RentingHistory);
+        }
+
+        [Ignore("This behavior is currently expected. SubmitChanges() uses DocumentBatchWrite, which only supports PUT operations with default 'replace' behavior")]
+        [Test]
+        public void DataContext_EntityModification_UpdateShouldNotAffectFieldsModifiedFromOutside()
+        {
+            var book = BookPocosHelper.CreateBookPoco(popularityRating: BookPoco.Popularity.Average, persistToDynamoDb: false);
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.InsertOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            // Update record from outside of DataTable
+            BookPocosHelper.CreateBookPoco(book.Name, book.PublishYear, numPages: 15);
+
+            book.PopularityRating = BookPoco.Popularity.High;
+            this.Context.SubmitChanges();
+
+            var storedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+            Assert.AreEqual(book.PopularityRating, storedBookPoco.PopularityRating, "Record was not updated");
+            Assert.AreEqual(book.NumPages, 15, "Update has erased changes from outside");
+        }
+
+        [Test]
+        public void DataContext_UpdateEntity_UpdatesRecordWhenOldRecordIsNull()
+        {
+            var book = BookPocosHelper.CreateBookPoco(popularityRating: BookPoco.Popularity.Average);
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+
+            book.PopularityRating = BookPoco.Popularity.High;
+            ((ITableCudOperations)booksTable).UpdateEntity(book, null);
+
+            var storedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+            Assert.AreEqual(book.PopularityRating, storedBookPoco.PopularityRating, "Record was not updated");
+        }
+
+        [Test]
+        public void DataContext_UpdateEntity_UpdatesRecordWhenOldRecordDoesNotMatchNewRecord()
+        {
+            var book = BookPocosHelper.CreateBookPoco(popularityRating: BookPoco.Popularity.Average);
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            var storedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+
+            storedBookPoco.PopularityRating = BookPoco.Popularity.High;
+            ((ITableCudOperations)booksTable).UpdateEntity(storedBookPoco, book);
+
+            var updatedBookPoco = booksTable.Find(book.Name, book.PublishYear);
+            Assert.AreEqual(storedBookPoco.PopularityRating, updatedBookPoco.PopularityRating, "Record was not updated");
+        }
+    }
+}

--- a/Sources/Linq2DynamoDb.DataContext.Tests/EntityManagementTests/Poco/PocoRemovalTests.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/EntityManagementTests/Poco/PocoRemovalTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using Linq2DynamoDb.DataContext.Tests.Entities;
+using Linq2DynamoDb.DataContext.Tests.Helpers;
+using NUnit.Framework;
+
+namespace Linq2DynamoDb.DataContext.Tests.EntityManagementTests.Poco
+{
+    [TestFixture]
+    public class PocoRemovalTests : DataContextTestBase
+    {
+        public override void SetUp()
+        {
+            this.Context = TestConfiguration.GetDataContext();
+        }
+
+        public override void TearDown()
+        {
+        }
+
+        [Test]
+        public void DataContext_EntityRemoval_RemovesExistingRecordFromDynamoDb()
+        {
+            var book = BookPocosHelper.CreateBookPoco();
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.RemoveOnSubmit(book);
+            this.Context.SubmitChanges();
+
+            var storedBookPocosCount = booksTable.Count(storedBookPoco => storedBookPoco.Name == book.Name);
+            Assert.AreEqual(0, storedBookPocosCount, "Record was not deleted");
+        }
+
+        [Test]
+        public void DataContext_EntityRemoval_DoesNotThrowAnyExceptionsIfRecordToRemoveDoesNotExist()
+        {
+            var book = BookPocosHelper.CreateBookPoco(persistToDynamoDb: false);
+
+            var booksTable = this.Context.GetTable<BookPoco>();
+            booksTable.RemoveOnSubmit(book);
+            this.Context.SubmitChanges();
+        }
+    }
+}

--- a/Sources/Linq2DynamoDb.DataContext.Tests/Helpers/BookPocoHelper.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/Helpers/BookPocoHelper.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Web.Script.Serialization;
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.Model;
+using Linq2DynamoDb.DataContext.Tests.Entities;
+using log4net;
+
+namespace Linq2DynamoDb.DataContext.Tests.Helpers {
+    public static class BookPocosHelper {
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(BooksHelper));
+
+        private static readonly IAmazonDynamoDB DynamoDbClient = TestConfiguration.GetDynamoDbClient();
+        private static readonly DynamoDBContext PersistenceContext = TestConfiguration.GetDynamoDbContext();
+        private static ConcurrentQueue<BookPoco> _recordsForCleanup;
+
+        public static void StartSession() {
+            CreateBooksTable(TestConfiguration.TablePrefix + "BookPoco");
+            _recordsForCleanup = new ConcurrentQueue<BookPoco>();
+        }
+
+        public static void CleanSession() {
+            Logger.DebugFormat("Removing {0} records from DynamoDb", _recordsForCleanup.Count);
+
+            Parallel.ForEach(_recordsForCleanup, book => PersistenceContext.Delete(book));
+
+            _recordsForCleanup = new ConcurrentQueue<BookPoco>();
+        }
+
+        public static BookPoco CreateBookPoco(
+            string name = null,
+            int publishYear = default(int),
+            string author = default(string),
+            int numPages = default(int),
+            BookPoco.Popularity popularityRating = default(BookPoco.Popularity),
+            BookPoco.Stars userFeedbackRating = default(BookPoco.Stars),
+            List<string> rentingHistory = default(List<string>),
+            IDictionary<string, TimeSpan> filmsBasedOnBook = default(IDictionary<string, TimeSpan>),
+            DateTime lastRentTime = default(DateTime),
+            bool persistToDynamoDb = true,
+            BookPoco.PublisherDto publisher = default(BookPoco.PublisherDto),
+            List<BookPoco.ReviewDto> reviews = default(List<BookPoco.ReviewDto>)) {
+            name = name ?? "TestBook" + Guid.NewGuid();
+
+            var book = new BookPoco {
+                Name = name,
+                PublishYear = publishYear,
+                Author = author,
+                NumPages = numPages,
+                PopularityRating = popularityRating,
+                UserFeedbackRating = userFeedbackRating,
+                RentingHistory = rentingHistory,
+                FilmsBasedOnBook = filmsBasedOnBook,
+                LastRentTime = lastRentTime,
+                Publisher = publisher,
+                ReviewsList = reviews,
+            };
+
+            var bookData = new JavaScriptSerializer().Serialize(book);
+
+            if (persistToDynamoDb) {
+                Logger.DebugFormat("Persisting book: {0}", bookData);
+                PersistenceContext.Save(book);
+            } else {
+                Logger.DebugFormat("Created in-memory book: {0}", bookData);
+            }
+
+            if (_recordsForCleanup != null) {
+                _recordsForCleanup.Enqueue(book);
+            }
+
+            return book;
+        }
+
+        public static void CreateBooksTable(string tableName) {
+            try {
+                DynamoDbClient.CreateTable(
+                    new CreateTableRequest {
+                        TableName = tableName,
+                        AttributeDefinitions =
+                            new List<AttributeDefinition>
+                            {
+                                new AttributeDefinition { AttributeName = "Name", AttributeType = "S" },
+                                new AttributeDefinition { AttributeName = "PublishYear", AttributeType = "N" }
+                            },
+                        ProvisionedThroughput = new ProvisionedThroughput { ReadCapacityUnits = 5, WriteCapacityUnits = 5 },
+                        KeySchema =
+                            new List<KeySchemaElement>
+                            {
+                                new KeySchemaElement { AttributeName = "Name", KeyType = "HASH" },
+                                new KeySchemaElement { AttributeName = "PublishYear", KeyType = "RANGE" }
+                            }
+                    });
+
+                Logger.DebugFormat("Created table {0}", tableName);
+            } catch {
+                Logger.DebugFormat("Table already existed {0}", tableName);
+            }
+        }
+    }
+}

--- a/Sources/Linq2DynamoDb.DataContext.Tests/Linq2DynamoDb.DataContext.Tests.csproj
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/Linq2DynamoDb.DataContext.Tests.csproj
@@ -78,10 +78,15 @@
     <Compile Include="CachingTests\StringFieldComparisonTests.cs" />
     <Compile Include="CachingTests\TableCacheTestsBase.cs" />
     <Compile Include="DataContextTests.cs" />
+    <Compile Include="Entities\BookPoco.cs" />
     <Compile Include="Entities\BooksComparer.cs" />
     <Compile Include="EntityManagementTests\EntityCreationTests.cs" />
     <Compile Include="EntityManagementTests\EntityModificationTests.cs" />
     <Compile Include="EntityManagementTests\EntityRemovalTests.cs" />
+    <Compile Include="EntityManagementTests\Poco\PocoCreationTests.cs" />
+    <Compile Include="EntityManagementTests\Poco\PocoModificationTests.cs" />
+    <Compile Include="EntityManagementTests\Poco\PocoRemovalTests.cs" />
+    <Compile Include="Helpers\BookPocoHelper.cs" />
     <Compile Include="Helpers\BooksHelper.cs" />
     <Compile Include="Helpers\MemcachedController.cs" />
     <Compile Include="IndexTests\GlobalSecondaryIndexTests.cs" />

--- a/Sources/Linq2DynamoDb.DataContext/EntityWrapper.cs
+++ b/Sources/Linq2DynamoDb.DataContext/EntityWrapper.cs
@@ -63,6 +63,8 @@ namespace Linq2DynamoDb.DataContext
                     &&
                     (!(field.Value is DynamoDBList))
                     &&
+                    (!(field.Value is PrimitiveList))
+                    &&
                     (field.Value.AsString() == null)
                 )
                 {


### PR DESCRIPTION
Changes: 
- Add test that shows this behavior does not happen with objects that inherit from EntityBase
- Add test that shows this behavior happens with POCOs (included other tests for completeness to ensure that other POCO operations do succeed) 
- Proposed fix in EntityWrapper.cs (check `field.Value is PrimitiveList`) 