### PR TITLE
Race conditions with DataContext

### DIFF
--- a/Sources/Linq2DynamoDb.AspNet.DataSource/UpdatableDataContext.cs
+++ b/Sources/Linq2DynamoDb.AspNet.DataSource/UpdatableDataContext.cs
@@ -147,7 +147,7 @@ namespace Linq2DynamoDb.DataContext
             // The only thing we can do is to try to remove the entity from all of them.
             foreach (var pair in this.TableWrappers.Where(pair => pair.Key.Item1 == entityType))
             {
-                pair.Value.RemoveEntity(targetResource);
+                pair.Value.Value.RemoveEntity(targetResource);
             }
         }
 
@@ -165,7 +165,7 @@ namespace Linq2DynamoDb.DataContext
         {
             foreach (var pair in this.TableWrappers)
             {
-                pair.Value.ClearModifications();
+                pair.Value.Value.ClearModifications();
             }
         }
 

--- a/Sources/Linq2DynamoDb.DataContext.Tests/DataContextTests.cs
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/DataContextTests.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
 using Linq2DynamoDb.DataContext.Tests.Entities;
-
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Linq2DynamoDb.DataContext.Tests
@@ -50,6 +52,104 @@ namespace Linq2DynamoDb.DataContext.Tests
             //TODO: figure out a way to directly prove that the tablename prefix is getting applied, rather than this indirect approach
             var result = table.FirstOrDefault();
             Assert.IsNotNull(result);
+        }
+
+        /// <remarks>Set to run 10 (magic number) times, as race conditions are hard to get to consistently fail.</remarks>
+        [Test, Repeat(10)]
+        public async Task GetTableDefinitionRaceConditionRunningSomewhatInParallelSynchronised()
+        {
+            //setup fake dynamodb interactions
+            var dynamoDbClient = Substitute.For<IAmazonDynamoDB>();
+            dynamoDbClient.DescribeTable(Arg.Any<DescribeTableRequest>()).Returns(new DescribeTableResponse
+            {
+                Table = new TableDescription { TableStatus = TableStatus.ACTIVE, KeySchema = new List<KeySchemaElement> { new KeySchemaElement("key", KeyType.HASH) }, AttributeDefinitions = new List<AttributeDefinition> { new AttributeDefinition("key", ScalarAttributeType.S) } }
+            });
+
+            //subject
+            var context = new DataContext(dynamoDbClient);
+            context.CreateTableIfNotExists(new CreateTableArgs<Book>(c => c.Name));
+
+            const int numberOfRacers = 10;
+
+            //exercise
+            var checkeredFlag = new SemaphoreSlim(0);
+            var racers = Enumerable.Range(0, numberOfRacers).Select(i => Task.Run(async () =>
+            {
+                await checkeredFlag.WaitAsync();
+                return context.GetTable<Book>();
+            }));
+            checkeredFlag.Release(numberOfRacers);
+            var tables = await Task.WhenAll(racers);
+            var actual = tables.OfType<ITableCudOperations>().Select(t => t.TableWrapper).ToList();
+
+            //assert
+            var expected = Enumerable.Repeat(actual.First(), numberOfRacers).ToList();
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        /// <remarks>Set to run 10 (magic number) times, as race conditions are hard to get to consistently fail.</remarks>
+        [Test, Repeat(10)]
+        public async Task GetTableDefinitionRaceConditionRunningAsCloseToParallelSynchronised()
+        {
+            //setup fake dynamodb interactions
+            var dynamoDbClient = Substitute.For<IAmazonDynamoDB>();
+            dynamoDbClient.DescribeTable(Arg.Any<DescribeTableRequest>()).Returns(new DescribeTableResponse
+            {
+                Table = new TableDescription { TableStatus = TableStatus.ACTIVE, KeySchema = new List<KeySchemaElement> { new KeySchemaElement("key", KeyType.HASH) }, AttributeDefinitions = new List<AttributeDefinition> { new AttributeDefinition("key", ScalarAttributeType.S) } }
+            });
+
+            //subject
+            var context = new DataContext(dynamoDbClient);
+            context.CreateTableIfNotExists(new CreateTableArgs<Book>(c => c.Name));
+
+            const int numberOfRacers = 10;
+
+            //exercise
+            var flagman = new AsyncBarrier(numberOfRacers);
+            var racers = Enumerable.Range(0, numberOfRacers).Select(i => Task.Run(async () =>
+            {
+                await flagman.SignalAndWait();
+                return context.GetTable<Book>();
+            }));
+
+            var tables = await Task.WhenAll(racers);
+            var actual = tables.OfType<ITableCudOperations>().Select(t => t.TableWrapper).ToList();
+
+            //assert
+            var expected = Enumerable.Repeat(actual.First(), numberOfRacers).ToList();
+            CollectionAssert.AreEqual(expected, actual);
+        }
+    }
+
+    /// <summary>
+    /// Thanks to Stephen Toub :)
+    /// http://blogs.msdn.com/b/pfxteam/archive/2012/02/11/10266932.aspx
+    /// </summary>
+    public class AsyncBarrier
+    {
+        private readonly int _participantCount;
+        private int _remainingParticipants;
+        private ConcurrentStack<TaskCompletionSource<bool>> m_waiters;
+
+        public AsyncBarrier(int participantCount)
+        {
+            if (participantCount <= 0) throw new ArgumentOutOfRangeException(nameof(participantCount));
+            _remainingParticipants = _participantCount = participantCount;
+            m_waiters = new ConcurrentStack<TaskCompletionSource<bool>>();
+        }
+
+        public Task SignalAndWait()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            m_waiters.Push(tcs);
+            if (Interlocked.Decrement(ref _remainingParticipants) == 0)
+            {
+                _remainingParticipants = _participantCount;
+                var waiters = m_waiters;
+                m_waiters = new ConcurrentStack<TaskCompletionSource<bool>>();
+                Parallel.ForEach(waiters, w => w.SetResult(true));
+            }
+            return tcs.Task;
         }
     }
 }

--- a/Sources/Linq2DynamoDb.DataContext.Tests/Linq2DynamoDb.DataContext.Tests.csproj
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/Linq2DynamoDb.DataContext.Tests.csproj
@@ -51,6 +51,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\log4net.2.0.2\lib\net40-full\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/Sources/Linq2DynamoDb.DataContext.Tests/packages.config
+++ b/Sources/Linq2DynamoDb.DataContext.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="AWSSDK.DynamoDBv2" version="3.1.1.5" targetFramework="net45" />
   <package id="EnyimMemcached" version="2.12" targetFramework="net45" />
   <package id="log4net" version="2.0.2" targetFramework="net45" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="StackExchange.Redis" version="1.0.488" targetFramework="net45" />
 </packages>

--- a/Sources/Linq2DynamoDb.DataContext/DataContext.cs
+++ b/Sources/Linq2DynamoDb.DataContext/DataContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon;
@@ -124,7 +125,7 @@ namespace Linq2DynamoDb.DataContext
             var tableWrapper = TableWrappers.GetOrAdd
             (
                 new Tuple<Type, object>(entityType, hashKeyValue),
-                t =>
+                t => new Lazy<TableDefinitionWrapper>(() =>
                 {
                     // if cache is not provided, then passing a fake implementation
                     var cacheImplementation =
@@ -144,8 +145,8 @@ namespace Linq2DynamoDb.DataContext
                     );
                     wrapper.OnLog += this.OnLog;
                     return wrapper;
-                }
-            );
+                }, LazyThreadSafetyMode.ExecutionAndPublication)
+            ).Value;
 
             if (tableWrapper.TableDefinition != tableDefinition)
             {
@@ -171,7 +172,7 @@ namespace Linq2DynamoDb.DataContext
         /// </summary>
         public void SubmitChanges()
         {
-            Task.WaitAll(this.TableWrappers.Values.Select(t => t.SubmitChangesAsync()).ToArray());
+            Task.WaitAll(this.TableWrappers.Values.Select(t => t.Value.SubmitChangesAsync()).ToArray());
         }
 
         #endregion
@@ -193,7 +194,7 @@ namespace Linq2DynamoDb.DataContext
         /// <summary>
         /// TableDefinitionWrapper instances for each entity type and HashKey value (if specified)
         /// </summary>
-        protected internal readonly ConcurrentDictionary<Tuple<Type, object>, TableDefinitionWrapper> TableWrappers = new ConcurrentDictionary<Tuple<Type, object>, TableDefinitionWrapper>();
+        protected internal readonly ConcurrentDictionary<Tuple<Type, object>, Lazy<TableDefinitionWrapper>> TableWrappers = new ConcurrentDictionary<Tuple<Type, object>, Lazy<TableDefinitionWrapper>>();
 
         /// <summary>
         /// A fake cache implementation, which does no caching
@@ -201,7 +202,7 @@ namespace Linq2DynamoDb.DataContext
         private static readonly ITableCache FakeCacheImplementation = new FakeTableCache(); 
 
 
-        private class CachedTableDefinitions : ConcurrentDictionary<string, Table>
+        private class CachedTableDefinitions : ConcurrentDictionary<string, Lazy<Table>>
         {
             /// <summary>
             /// Instead of storing a reference to DynamoDBClient we're storing it's HashCode
@@ -218,6 +219,11 @@ namespace Linq2DynamoDb.DataContext
                 return this._dynamoDbClientHashCode == client.GetHashCode();
             }
         }
+
+        /// <summary>
+        /// Used to lock while updating the <see cref="_cachedTableDefinitions" /> field
+        /// </summary>
+        private static readonly object CacheTableDefinitionsLock = new object();
 
         /// <summary>
         /// Table objects are cached here per DynamoDBClient instance.
@@ -269,20 +275,28 @@ namespace Linq2DynamoDb.DataContext
                 throw new InvalidOperationException("An instance of AmazonDynamoDbClient was not provided. Use either a ctor, that takes AmazonDynamoDbClient instance or GetTable() method, that takes Table object");
             }
 
-            var cachedTableDefinitions = _cachedTableDefinitions;
             if
             (
-                (cachedTableDefinitions == null)
+                (_cachedTableDefinitions == null)
                 ||
-                (!cachedTableDefinitions.IsAssignedToThisClientInstance(this._client))
+                (!_cachedTableDefinitions.IsAssignedToThisClientInstance(this._client))
             )
             {
-                cachedTableDefinitions = new CachedTableDefinitions(this._client);
-                _cachedTableDefinitions = cachedTableDefinitions;
+                lock (CacheTableDefinitionsLock)
+                {
+                    if ((_cachedTableDefinitions == null)
+                        ||
+                        (!_cachedTableDefinitions.IsAssignedToThisClientInstance(this._client)))
+                    {
+                        _cachedTableDefinitions = new CachedTableDefinitions(this._client);
+                    }
+                }
             }
 
+            var cachedTableDefinitions = _cachedTableDefinitions;
+
             string tableName = this.GetTableNameForType(entityType);
-            return cachedTableDefinitions.GetOrAdd(tableName, name => Table.LoadTable(this._client, name));
+            return cachedTableDefinitions.GetOrAdd(tableName, name => new Lazy<Table>(() => Table.LoadTable(this._client, name), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
         }
 
         #endregion

--- a/Sources/Linq2DynamoDb.DataContext/DataContextExtensions.cs
+++ b/Sources/Linq2DynamoDb.DataContext/DataContextExtensions.cs
@@ -23,7 +23,7 @@ namespace Linq2DynamoDb.DataContext
         /// </summary>
         public static async Task SubmitChangesAsync(this DataContext context)
         {
-            await Task.WhenAll(context.TableWrappers.Values.Select(t => t.SubmitChangesAsync()));
+            await Task.WhenAll(context.TableWrappers.Values.Select(t => t.Value.SubmitChangesAsync()));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes a few race condition bugs in DataContext, with ConcurrentDictionary.GetOrAdd as mentioned in MSDN. Also synchronised replacement of the static _cachedTableDefinitions field.

We were occasionally getting the:
```c#
throw new InvalidOperationException("You shouldn't pass different Table instances for the same entityType/hashKeyValue pair");
```
https://msdn.microsoft.com/en-us/library/dd997369.aspx (ConcurrentDictionary.GetOrAdd)
https://msdn.microsoft.com/en-us/library/ff650316.aspx (Double-checked locking singleton/static)